### PR TITLE
Allow generated files mixed with sources

### DIFF
--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 # Type-checks, and emits output to
 # bazel-bin/examples/simple/foo.js
@@ -9,10 +10,24 @@ ts_project(
     declaration = True,
 )
 
+# Code generation tools can produce .ts outputs.
+# This example just writes one directly to bazel-bin.
+write_file(
+    name = "code_generation",
+    out = "generated.ts",
+    content = [
+        "export const data: string[] = []",
+    ],
+)
+
 # Writes output to bazel-bin/examples/simple/build/foo.js
 ts_project(
     name = "outdir",
-    srcs = ["foo.ts"],
+    srcs = [
+        "foo.ts",
+        "generated.ts",
+    ],
+    # A tsconfig.json file will be generated with this content
     tsconfig = {
         "compilerOptions": {
             "outDir": "build",

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -211,8 +211,6 @@ def _calculate_typing_maps_outs(srcs, typings_out_dir, root_dir, declaration_map
     return _out_paths(srcs, typings_out_dir, root_dir, allow_js, exts)
 
 def _calculate_root_dir(ctx):
-    some_generated_path = None
-    some_source_path = None
     root_path = None
 
     # Note we don't have access to the ts_project macro allow_js param here.
@@ -223,18 +221,8 @@ def _calculate_root_dir(ctx):
     # a breaking change to restrict it further.
     allow_js = True
     for src in ctx.files.srcs:
-        if _is_ts_src(src.path, allow_js):
-            if src.is_source:
-                some_source_path = src.path
-            else:
-                some_generated_path = src.path
-                root_path = ctx.bin_dir.path
-
-    if some_source_path and some_generated_path:
-        fail("ERROR: %s srcs cannot be a mix of generated files and source files " % ctx.label +
-             "since this would prevent giving a single rootDir to the TypeScript compiler\n" +
-             "    found generated file %s and source file %s" %
-             (some_generated_path, some_source_path))
+        if not _is_ts_src(src.path, allow_js):
+            root_path = ctx.bin_dir.path
 
     return _join(
         root_path,


### PR DESCRIPTION
Now that we rely on rules_js, sources are copied to the output tree so they are next to generated ones by the time typescript sees them. That means there's no problem giving TS a common rootDir between the two.