### PR TITLE
refactor: only set tsconfig.json as the default if the file exists

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -92,7 +92,7 @@ For the list of args, see the ts_project rule.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="ts_project-name"></a>name |  <p align="center"> - </p>   |  none |
-| <a id="ts_project-tsconfig"></a>tsconfig |  <p align="center"> - </p>   |  <code>"tsconfig.json"</code> |
+| <a id="ts_project-tsconfig"></a>tsconfig |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="ts_project-srcs"></a>srcs |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="ts_project-args"></a>args |  <p align="center"> - </p>   |  <code>[]</code> |
 | <a id="ts_project-data"></a>data |  <p align="center"> - </p>   |  <code>[]</code> |

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -37,7 +37,7 @@ def _validate_options_impl(ctx):
         incremental = ctx.attr.incremental,
         ts_build_info_file = ctx.attr.ts_build_info_file,
     )
-    arguments.add_all([ctx.file.tsconfig.path, marker.short_path, ctx.attr.target, json.encode(config)])
+    arguments.add_all([ctx.file.tsconfig.short_path, marker.short_path, ctx.attr.target, json.encode(config)])
 
     inputs = _tsconfig_inputs(ctx)
 


### PR DESCRIPTION
Otherwise give a better error that the user needs to set the tsconfig attribute.
Previously the error was

```
ERROR: /home/alexeagle/Projects/bazel-examples/next.js/lib/BUILD.bazel:3:11: Copying file lib/tsconfig.json failed: missing input file '//lib:tsconfig.json'
```