### PR TITLE
fix: handle option changes and implement default lib cache

### DIFF
--- a/e2e/worker/test.sh
+++ b/e2e/worker/test.sh
@@ -82,4 +82,11 @@ message "# Case 6: Builds with local strategy"
 bazel clean
 bazel build :lib --strategy=TsProject=local
 
+message "# Case 7: Should dump traces"
+bazel clean
+tracepath="/tmp/tsctraces"
+rm -rf $tracepath
+bazel build //trace
+[ ! -d $tracepath ] && exit_with_message "Case 7: Expected tsc to write traces"
+
 message "All tests have passed"

--- a/e2e/worker/trace/BUILD
+++ b/e2e/worker/trace/BUILD
@@ -1,0 +1,13 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+
+ts_project(
+    name = "trace",
+    srcs = ["index.ts"],
+    tsconfig = {},
+    args = [
+        "--generateTrace",
+        "/tmp/tsctraces"
+    ]
+)
+


### PR DESCRIPTION
Changes to worker mode

- Implements [typescript performance tracing](https://github.com/microsoft/TypeScript/wiki/Performance-Tracing) which is available in `4.1` and above in addition to performance timings. 
- Implements caching of  `typescript/lib` ASTs across workers so that cost is paid once for each worker
- Fixes #50 

New tracing API can be enabled per target

```starlark
ts_project(
    name = "ts",
    args = [
        "--generateTrace",
        "/absolute/path/to/workspace/traces"
    ]
)
```

`/absolute/path/to/workspace/traces` can be relative as well but in that case tsc will put traces into `bazel-bin/path/to/target/<relative_path>`.