### PR TITLE
fix: relative path computation handles parent dir

### DIFF
--- a/examples/extends_chain/main/BUILD.bazel
+++ b/examples/extends_chain/main/BUILD.bazel
@@ -1,7 +1,21 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
+# Uses tsconfig.json in this source folder by default
 ts_project(
     name = "main",
     srcs = ["main.ts"],
     extends = "//examples/extends_chain:tsconfig_node",
+)
+
+# Alternately, we could define tsconfig dictionary
+ts_project(
+    name = "config_dict",
+    srcs = ["main.ts"],
+    extends = "//examples/extends_chain:tsconfig_node",
+    out_dir = "config_dict",
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": False,
+        },
+    },
 )


### PR DESCRIPTION
Without the fix, the new 'config_dict' example failed with bad pathing computation, like
error TS5012: Cannot read file '/shared/cache/bazel/user_base/b7a032561a02207b8d9235ce01302e53/execroot/aspect_rules_ts/bazel-out/k8-fastbuild/bin/examples/extends_chain/main/fig.node.json'

fixes #60