### PR TITLE
fix: fix declaration file output with out_dir set

### DIFF
--- a/examples/out_dir/BUILD.bazel
+++ b/examples/out_dir/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "out_dir-tsconfig",
+    srcs = ["main.ts"],
+    tsconfig = {
+        "compilerOptions": {
+            "outDir": "tsconfig",
+            "declaration": True,
+            "declarationMap": True
+        }
+    }
+)
+
+ts_project(
+    name = "out_dir-params",
+    srcs = ["main.ts"],
+    out_dir = "param",
+    declaration = True,
+    declaration_map = True,
+    tsconfig = {}
+)
+
+ts_project(
+    name = "out_dir-declaration_dir",
+    srcs = ["main.ts"],
+    out_dir = "declaration_dir",
+    declaration_dir = "decl_map",
+    declaration = True,
+    declaration_map = True,
+    tsconfig = {}
+)

--- a/examples/out_dir/main.ts
+++ b/examples/out_dir/main.ts
@@ -1,0 +1,1 @@
+console.log('hello world')

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -60,7 +60,7 @@ def _ts_project_impl(ctx):
         _lib.calculate_root_dir(ctx),
     ])
     if len(typings_outs) > 0:
-        declaration_dir = _lib.join(ctx.label.package, ctx.attr.declaration_dir) if ctx.attr.declaration_dir else ctx.label.package
+        declaration_dir = _lib.join(ctx.label.package, typings_out_dir)
         if declaration_dir == "":
             declaration_dir = "."
         arguments.add_all([


### PR DESCRIPTION
The default `declaration_dir` was already calculated up above taking `out_dir` into account.

I'm not sure if `examples` is really the best place to test this? 2/3 of those failed to build without this fix...