### PR TITLE
test: add build_test for examples

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 # Building this target results in bazel-bin/examples/node_modules/@myorg/js_lib, so that
 # TypeScript and other node programs beneath bazel-bin/examples are able to resolve its location.
@@ -12,3 +13,16 @@ npm_link_package(
 
 # This macro expands to a npm_link_package for each third-party package in package.json
 npm_link_all_packages(name = "node_modules")
+
+
+build_test(
+    name = "test",
+    targets = [
+        "//examples/simple:ts",
+        "//examples/ts_project_dep/b:ts",
+        "//examples/out_dir:out_dir-tsconfig",
+        "//examples/out_dir:out_dir-params",
+        "//examples/out_dir:out_dir-declaration_dir",
+        "//examples/json:ts",
+    ],
+)

--- a/examples/json/BUILD.bazel
+++ b/examples/json/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
+package(default_visibility = ["//examples:__pkg__"])
+
 # Demonstrates the --resolveJsonModule feature of TypeScript
 ts_project(
     name = "ts",

--- a/examples/out_dir/BUILD.bazel
+++ b/examples/out_dir/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
+package(default_visibility = ["//examples:__pkg__"])
+
 ts_project(
     name = "out_dir-tsconfig",
     srcs = ["main.ts"],

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
+package(default_visibility = ["//examples:__pkg__"])
+
 # Dependencies for all targets in this package
 _DEPS = [
     "//examples:node_modules/@myorg/js_lib",

--- a/examples/ts_project_dep/b/BUILD.bazel
+++ b/examples/ts_project_dep/b/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
+package(default_visibility = ["//examples:__pkg__"])
+
 ts_project(
     name = "ts",
     srcs = ["b.ts"],


### PR DESCRIPTION
these targets are not built as part of our CI pipeline which makes it prone to go unnoticed in case of a breakage.