### PR TITLE
perf: minimize the amount fs calls worker makes

### DIFF
--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -1,8 +1,11 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load(":mock_transpiler.bzl", "mock")
 load(":transpiler_tests.bzl", "transpiler_test_suite")
 load("//ts:defs.bzl", "ts_project")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+
 
 _TSCONFIG = {
     "compilerOptions": {
@@ -86,3 +89,18 @@ ts_project(
 )
 
 transpiler_test_suite()
+
+
+copy_file(
+    name = "copy_ts_project_worker",
+    src = "//ts/private:ts_project_worker.js",
+    out = "ts_project_worker.js",
+)
+
+js_test(
+    name = "worker_test",
+    entry_point = ":ts_project_worker.test.js",
+    data = [
+        ":ts_project_worker.js"
+    ]
+)

--- a/ts/test/ts_project_worker.test.js
+++ b/ts/test/ts_project_worker.test.js
@@ -1,0 +1,86 @@
+const assert = require("node:assert");
+const path = require("node:path");
+const fs = require("node:fs");
+const mod = require('node:module');
+
+function mock(name, exports) {
+    const p = path.resolve(name);
+    require.cache[p] = {
+        id: name,
+        file: p,
+        loaded: true,
+        exports: exports
+    };
+    const realres = mod._resolveFilename;
+    mod._resolveFilename = function (request, parent) {
+        if (request == name) {
+            return p;
+        }
+        return realres(request, parent);
+    };
+}
+
+mock("typescript", { sys: { getCurrentDirectory: () => {}, realpath: fs.realpathSync } });
+mock("@bazel/worker", { log: console.log })
+
+/** @type {import("../private/ts_project_worker")} */
+const worker = require("./ts_project_worker");
+
+
+
+
+// Tests
+const root = process.env.GTEST_TMP_DIR;
+
+fs.mkdirSync(path.join(root, "symlink"));
+fs.symlinkSync(path.join(root, "symlink"), path.join(root, "symlinked"), "dir");
+
+fs.mkdirSync(path.join(root, 'no_a_symlink_but_null', 'deep'), {recursive: true});
+fs.writeFileSync(path.join(root, 'no_a_symlink_but_null', 'deep', "input.js"), "")
+
+const tree = worker.createFilesystemTree(root, {
+    "tree/subtree/input.js": "1",
+    "tree/input.js": "2",
+    "symlink/to/me/input.js": "3",
+    "symlinked": null,
+    "no_a_symlink_but_null/deep/input.js": null,
+});
+
+
+assert.ok(tree.directoryExists("symlinked/to/me"));
+assert.ok(!tree.fileExists("symlinked/to/me"));
+assert.ok(!tree.fileExists("symlinked"));
+assert.ok(tree.directoryExists("symlinked"));
+assert.deepStrictEqual(tree.getDirectories("symlinked"), ["to"])
+assert.deepStrictEqual(tree.readDirectory("symlinked"), ["to"])
+assert.deepStrictEqual(tree.readDirectory("symlinked/to/me"), ["input.js"])
+
+assert.deepStrictEqual(tree.readDirectory("no_a_symlink_but_null"), ["deep"])
+
+
+assert.deepStrictEqual(tree.getDirectories("tree"), ["subtree"]);
+assert.deepStrictEqual(tree.readDirectory("tree"), ["subtree", "input.js"]);
+
+
+assert.ok(tree.directoryExists("tree"));
+assert.ok(tree.directoryExists("tree/subtree"));
+assert.ok(!tree.directoryExists("tree/subtree/input.js"));
+
+assert.ok(tree.fileExists("tree/subtree/input.js"));
+assert.ok(!tree.fileExists("tree/subtree"));
+assert.ok(!tree.fileExists("tree"));
+
+
+tree.remove("symlinked");
+assert.ok(!tree.directoryExists("symlinked"));
+assert.ok(!tree.directoryExists("symlinked/to"));
+
+
+tree.add("symlinked/to/input.js", "1")
+assert.ok(tree.directoryExists("symlinked"));
+assert.ok(tree.directoryExists("symlinked/to"));
+assert.ok(tree.fileExists("symlinked/to/input.js"));
+
+tree.remove("symlinked/to/input.js");
+assert.ok(tree.directoryExists("symlinked"));
+assert.ok(!tree.directoryExists("symlinked/to"));


### PR DESCRIPTION
- Reduces the amount of tree walking tsc has to do when performing module resolution
- Improved reproducibility now that we create a virtual filesystem constructed with the `inputs` map bazel provides.
- Zero filesystem calls performed for `fileExists` `directoryExists` `readDirectory` `getDirectories`. Consequently, tsc performs less of other fs system calls given the limited view of the actual filesystem.

I'll perform some benchmarks to see how much we gained from this.

Closes #66 