### PR TITLE
feat: add support for .mts and .cts source files

### DIFF
--- a/examples/module_ext/BUILD.bazel
+++ b/examples/module_ext/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@aspect_bazel_lib//lib:params_file.bzl", "params_file")
+
+ts_project(
+    name = "module_ts",
+    srcs = [
+        "a.mts",
+        "b.mjs",
+        "c.cts",
+        "d.cjs",
+    ],
+    allow_js = True,
+    declaration = True,
+    declaration_map = True,
+    out_dir = "out",
+    source_map = True,
+)
+
+filegroup(
+    name = "types",
+    srcs = [":module_ts"],
+    output_group = "types",
+)
+
+params_file(
+    name = "params",
+    data = [
+        ":module_ts",
+        ":types",
+    ],
+    args = [
+        "$(rootpaths :types)",
+        "$(rootpaths :module_ts)",
+    ],
+    out = "outputs.txt"
+)
+
+write_source_files(
+    name = "write_params",
+    files = {
+        "expected_outputs.txt": "outputs.txt",
+    },
+)

--- a/examples/module_ext/a.mts
+++ b/examples/module_ext/a.mts
@@ -1,0 +1,1 @@
+export const A = "a";

--- a/examples/module_ext/b.mjs
+++ b/examples/module_ext/b.mjs
@@ -1,0 +1,1 @@
+export const B = "b";

--- a/examples/module_ext/c.cts
+++ b/examples/module_ext/c.cts
@@ -1,0 +1,1 @@
+export const C = "c";

--- a/examples/module_ext/d.cjs
+++ b/examples/module_ext/d.cjs
@@ -1,0 +1,1 @@
+export const D = "d";

--- a/examples/module_ext/expected_outputs.txt
+++ b/examples/module_ext/expected_outputs.txt
@@ -1,0 +1,14 @@
+examples/module_ext/out/a.d.mts
+examples/module_ext/out/a.d.mts.map
+examples/module_ext/out/b.d.mts
+examples/module_ext/out/b.d.mts.map
+examples/module_ext/out/c.d.cts
+examples/module_ext/out/c.d.cts.map
+examples/module_ext/out/d.d.cts
+examples/module_ext/out/d.d.cts.map
+examples/module_ext/out/a.mjs
+examples/module_ext/out/a.mjs.map
+examples/module_ext/out/b.mjs
+examples/module_ext/out/c.cjs
+examples/module_ext/out/c.cjs.map
+examples/module_ext/out/d.cjs

--- a/examples/module_ext/tsconfig.json
+++ b/examples/module_ext/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+      "allowJs": true,
+      "sourceMap": true,
+      "declaration": true,
+      "declarationMap": true
+    }
+}

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -153,9 +153,13 @@ def _relative_to_package(path, ctx):
     return path
 
 def _is_ts_src(src, allow_js):
-    if not src.endswith(".d.ts") and (src.endswith(".ts") or src.endswith(".tsx")):
-        return True
-    return allow_js and (src.endswith(".js") or src.endswith(".jsx"))
+    if (src.endswith(".ts") or src.endswith(".tsx") or src.endswith(".mts") or src.endswith(".cts")):
+        return not (src.endswith(".d.ts") or src.endswith(".d.mts") or src.endswith(".d.cts"))
+
+    if allow_js:
+        return (src.endswith(".js") or src.endswith(".jsx") or src.endswith(".mjs") or src.endswith(".cjs"))
+
+    return False
 
 def _is_json_src(src, resolve_json_module):
     return resolve_json_module and src.endswith(".json")
@@ -189,9 +193,16 @@ def _calculate_js_outs(srcs, out_dir, root_dir, allow_js, preserve_jsx, emit_dec
 
     exts = {
         "*": ".js",
-        ".jsx": ".jsx",
-        ".tsx": ".jsx",
-    } if preserve_jsx else {"*": ".js"}
+        ".mts": ".mjs",
+        ".mjs": ".mjs",
+        ".cjs": ".cjs",
+        ".cts": ".cjs",
+    }
+
+    if preserve_jsx:
+        exts[".jsx"] = ".jsx"
+        exts[".tsx"] = ".jsx"
+
     return _out_paths(srcs, out_dir, root_dir, allow_js, exts)
 
 def _calculate_map_outs(srcs, out_dir, root_dir, source_map, preserve_jsx, emit_declaration_only):
@@ -200,20 +211,42 @@ def _calculate_map_outs(srcs, out_dir, root_dir, source_map, preserve_jsx, emit_
 
     exts = {
         "*": ".js.map",
-        ".tsx": ".jsx.map",
-    } if preserve_jsx else {"*": ".js.map"}
+        ".mts": ".mjs.map",
+        ".cts": ".cjs.map",
+        ".mjs": ".mjs.map",
+        ".cjs": ".cjs.map",
+    }
+    if preserve_jsx:
+        exts[".tsx"] = ".jsx.map"
+
     return _out_paths(srcs, out_dir, root_dir, False, exts)
 
 def _calculate_typings_outs(srcs, typings_out_dir, root_dir, declaration, composite, allow_js, include_srcs = True):
     if not (declaration or composite):
         return []
-    return _out_paths(srcs, typings_out_dir, root_dir, allow_js, {"*": ".d.ts"})
+
+    exts = {
+        "*": ".d.ts",
+        ".mts": ".d.mts",
+        ".cts": ".d.cts",
+        ".mjs": ".d.mts",
+        ".cjs": ".d.cts",
+    }
+
+    return _out_paths(srcs, typings_out_dir, root_dir, allow_js, exts)
 
 def _calculate_typing_maps_outs(srcs, typings_out_dir, root_dir, declaration_map, allow_js):
     if not declaration_map:
         return []
 
-    exts = {"*": ".d.ts.map"}
+    exts = {
+        "*": ".d.ts.map",
+        ".mts": ".d.mts.map",
+        ".cts": ".d.cts.map",
+        ".mjs": ".d.mts.map",
+        ".cjs": ".d.cts.map",
+    }
+
     return _out_paths(srcs, typings_out_dir, root_dir, allow_js, exts)
 
 def _calculate_root_dir(ctx):


### PR DESCRIPTION
The file extensions allow individual files run by node to override the `type` in `package.json`. 

Added in typescript 4.7: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#new-file-extensions