### PR TITLE
test: add example of ts_project .d.ts source

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -10,5 +10,12 @@ npm_link_package(
     visibility = ["//examples:__subpackages__"],
 )
 
+npm_link_package(
+    name = "node_modules/@myorg/dts_lib",
+    src = "//examples/dts_lib",
+    root_package = "examples",
+    visibility = ["//examples:__subpackages__"],
+)
+
 # This macro expands to a npm_link_package for each third-party package in package.json
 npm_link_all_packages(name = "node_modules")

--- a/examples/dts_lib/BUILD.bazel
+++ b/examples/dts_lib/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+ts_project(
+    name = "lib_ts",
+    declaration = True,
+    srcs = ["index.ts", "lib_types.d.ts"],
+)
+
+js_library(
+    name = "lib",
+    deps = [":lib_ts"],
+)
+
+npm_package(
+    name = "dts_lib",
+    srcs = [":lib_ts"],
+    package = "@myorg/dts_lib",
+    visibility = ["//examples:__subpackages__"],
+)
+
+ts_project(
+    name = "importer_ts",
+    declaration = True,
+    srcs = ["importer.ts"],
+    deps = [
+        ":lib",
+        "//examples:node_modules/@myorg/dts_lib",
+    ],
+)

--- a/examples/dts_lib/importer.ts
+++ b/examples/dts_lib/importer.ts
@@ -1,0 +1,5 @@
+import { A as RelA } from './index';
+import { A as AbsA } from '@myorg/dts_lib';
+
+export const aa: AbsA = 42;
+export const a: RelA = 42;

--- a/examples/dts_lib/index.ts
+++ b/examples/dts_lib/index.ts
@@ -1,0 +1,1 @@
+export * from './lib_types';

--- a/examples/dts_lib/lib_types.d.ts
+++ b/examples/dts_lib/lib_types.d.ts
@@ -1,0 +1,1 @@
+export type A = number;

--- a/examples/dts_lib/tsconfig.json
+++ b/examples/dts_lib/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "declaration": true
+    }
+}

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -4,6 +4,7 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 # Dependencies for all targets in this package
 _DEPS = [
     "//examples:node_modules/@myorg/js_lib",
+    "//examples:node_modules/@myorg/dts_lib",
     "//examples:node_modules/@types/node",
     "//examples:node_modules/date-fns",
 ]

--- a/examples/simple/foo.ts
+++ b/examples/simple/foo.ts
@@ -1,8 +1,11 @@
 import num from '@myorg/js_lib'
+import { A } from '@myorg/dts_lib'
 import { format } from 'date-fns'
 
-export const a: string = `number: ${num}, date: ${format(
+export const a: A = 123;
+export const b: string = `number: ${num}, date: ${format(
     new Date(2014, 1, 11),
     'MM/dd/YYYY'
 )}`
-console.log(a)
+
+console.log(a, b)


### PR DESCRIPTION
A test for `ts_project` containing `.d.ts` source files and another `ts_project` importing via relative + named imports (`js_library` + linked `npm_package`).

It seems like this is not possible with rules_nodejs: https://github.com/bazelbuild/rules_nodejs/commit/7b42331ac0bfc962e58067f4f0ce7dea5ffa7148