### PR TITLE
chore: update to aspect_rules_js to latest commit hash

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -415,10 +415,10 @@ def ts_project(
         # Default target produced by the macro gives the js and map outs, with the transitive dependencies.
         js_library(
             name = name,
-            srcs = js_outs + map_outs,
-            # Include the tsc target so that this js_library can be a valid dep for downstream ts_project
-            # or other DeclarationInfo-aware rules.
-            deps = deps + [tsc_target_name],
+            # Include the tsc target in srcs to pick-up both the direct & transitive declaration outputs so
+            # that this js_library can be a valid dep for downstream ts_project or other DeclarationInfo-aware rules.
+            srcs = js_outs + map_outs + [tsc_target_name],
+            deps = deps,
             **common_kwargs
         )
 

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -55,9 +55,9 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
     maybe(
         http_archive,
         name = "aspect_rules_js",
-        sha256 = "be39996444ab94de605e21cdcaa9bc4965a96186329d776e400b47fefd540902",
-        strip_prefix = "rules_js-1.0.0-rc.0",
-        url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.0.0-rc.0.tar.gz",
+        sha256 = "d01c514f7471db19cd86d8c15fe95409fca34750969afac2087668761121ee6a",
+        strip_prefix = "rules_js-be1ee2e8f65ff9e086487110c1115a5eb4934231",
+        url = "https://github.com/aspect-build/rules_js/archive/be1ee2e8f65ff9e086487110c1115a5eb4934231.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
1.0.0-rc.2 breaks since we needed the fixes in https://github.com/aspect-build/rules_js/pull/323 and https://github.com/aspect-build/rules_js/pull/324