### PR TITLE
fix: add .d.mts/.d.cts in declaration info

### DIFF
--- a/examples/dts_lib/BUILD.bazel
+++ b/examples/dts_lib/BUILD.bazel
@@ -1,12 +1,14 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 ts_project(
     name = "lib_ts",
     srcs = [
         "index.ts",
         "lib_types.d.ts",
+        "lib_types_2.d.mts",
     ],
     declaration = True,
     # TODO: fix worker mode flaky bug when there are multiple ts_project targets in a package
@@ -45,4 +47,14 @@ ts_project(
     deps = [
         "//examples:node_modules/@myorg/dts_lib",
     ],
+)
+
+build_test(
+    name = "importer_rel_test",
+    targets = [":importer_rel_ts"],
+)
+
+build_test(
+    name = "importer_linked_test",
+    targets = [":importer_linked_ts"],
 )

--- a/examples/dts_lib/importer_linked.ts
+++ b/examples/dts_lib/importer_linked.ts
@@ -1,3 +1,4 @@
-import { A } from '@myorg/dts_lib'
+import { A, B } from '@myorg/dts_lib'
 
 export const a: A = 42
+export const b: B = 'Forty Two'

--- a/examples/dts_lib/importer_rel.ts
+++ b/examples/dts_lib/importer_rel.ts
@@ -1,3 +1,4 @@
-import { A } from './index'
+import { A, B } from './index'
 
 export const a: A = 42
+export const b: B = 'Forty Two'

--- a/examples/dts_lib/index.ts
+++ b/examples/dts_lib/index.ts
@@ -1,1 +1,2 @@
 export * from './lib_types';
+export * from './lib_types_2.mjs';

--- a/examples/dts_lib/lib_types_2.d.mts
+++ b/examples/dts_lib/lib_types_2.d.mts
@@ -1,0 +1,1 @@
+export type B = string;

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -149,9 +149,12 @@ def _relative_to_package(path, ctx):
             path = path[len(prefix):]
     return path
 
+def _is_typings_src(src):
+    return src.endswith(".d.ts") or src.endswith(".d.mts") or src.endswith(".d.cts")
+
 def _is_ts_src(src, allow_js):
     if (src.endswith(".ts") or src.endswith(".tsx") or src.endswith(".mts") or src.endswith(".cts")):
-        return not (src.endswith(".d.ts") or src.endswith(".d.mts") or src.endswith(".d.cts"))
+        return not _is_typings_src(src)
 
     if allow_js:
         return (src.endswith(".js") or src.endswith(".jsx") or src.endswith(".mjs") or src.endswith(".cjs"))
@@ -263,6 +266,7 @@ lib = struct(
     declare_outputs = _declare_outputs,
     join = _join,
     relative_to_package = _relative_to_package,
+    is_typings_src = _is_typings_src,
     is_ts_src = _is_ts_src,
     is_json_src = _is_json_src,
     out_paths = _out_paths,

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -125,7 +125,7 @@ def _ts_project_impl(ctx):
         ])
         outputs.append(ctx.outputs.buildinfo_out)
     output_sources = json_outs + js_outs + map_outs
-    typings_srcs = [s for s in ctx.files.srcs if s.path.endswith(".d.ts")]
+    typings_srcs = [s for s in ctx.files.srcs if _lib.is_typings_src(s.path)]
 
     if len(js_outs) + len(typings_outs) < 1:
         label = "//{}:{}".format(ctx.label.package, ctx.label.name)


### PR DESCRIPTION
Update ts_project rule to include both .d.mts and .d.cts declaration
files in DeclarationInfo provider

Also add test within existing dts_lib example