### PR TITLE
fix: ensure extends paths are relative

### DIFF
--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -39,6 +39,7 @@ ts_project(
         "foo.ts",
         "generated.ts",
     ],
+    extends = "tsconfig.json",
     # A tsconfig.json file will be generated with this content
     tsconfig = {
         "compilerOptions": {


### PR DESCRIPTION
TypeScript will try to resolve paths as npm packages otherwise

Fixes #124