### PR TITLE
fix: add file info to error for `tsc` overreach

### DIFF
--- a/ts/private/ts_project_worker.js
+++ b/ts/private/ts_project_worker.js
@@ -458,7 +458,7 @@ function createProgram(args, initialInputs) {
         const relative = path.relative(execRoot, filePath);
         // external lib are transitive sources thus not listed in the inputs map reported by bazel.
         if (!filesystemTree.fileExists(path.relative(execRoot, filePath)) && !isExternalLib(filePath) && !outputs.has(relative)) {
-            throw new Error(`tsc tried to read file that wasn't an input to it.`);
+            throw new Error(`tsc tried to read file (${filePath}) that wasn't an input to it.`);
         }
         return ts.sys.readFile(filePath, encoding);
     }


### PR DESCRIPTION
This data was part of this error previously but was removed in https://github.com/aspect-build/rules_ts/pull/77

I'm not sure if that was intentional, but I found it very helpful to have the data when trying to understand what was going wrong in my migration. So just a thought to add it back?