### PR TITLE
fix: `ts_project` fails if `root_dir` used deep in source tree

### DIFF
--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -179,7 +179,7 @@ def _out_paths(srcs, out_dir, root_dir, allow_js, ext_map):
     outs = []
     for f in srcs:
         if _is_ts_src(f, allow_js):
-            out = _join(out_dir, f[:f.rindex(".")].replace(rootdir_replace_pattern, "") + _replace_ext(f, ext_map))
+            out = _join(out_dir, f[:f.rindex(".")].replace(rootdir_replace_pattern, "", 1) + _replace_ext(f, ext_map))
 
             # Don't declare outputs that collide with inputs
             # for example, a.js -> a.js

--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -41,6 +41,12 @@ write_file(
     content = ["export const a: string = \"1\";"],
 )
 
+write_file(
+    name = "gen_deep_src",
+    out = "root/deep/root/deep_src.ts",
+    content = ["export const a: string = \"1\";"],
+)
+
 ts_project(
     name = "transpile",
     srcs = ["big.ts"],
@@ -90,6 +96,14 @@ ts_project(
 
 transpiler_test_suite()
 
+# Ensure that when determining output location, the `root_dir` attribute is only removed once.
+ts_project(
+    name = "rootdir_works_with_repeated_directory",
+    srcs = ["root/deep/root/deep_src.ts"],
+    transpiler = mock,
+    tsconfig = _TSCONFIG,
+    root_dir = "root",
+)
 
 copy_file(
     name = "copy_ts_project_worker",


### PR DESCRIPTION
Partner to https://github.com/bazelbuild/rules_nodejs/pull/3535, applying that fix here as well.

The issue is that when calculating the output, it's overzealously removing the root_dir matches. I'm happy to change this to be whatever we think is clearest, because right now it is a bit magic-number-y.