### PR TITLE
chore: update to bazel 5.2.0

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-5.1.0
+5.2.0
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/e2e/bzlmod/.bazelversion
+++ b/e2e/bzlmod/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/worker/.bazelversion
+++ b/e2e/worker/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/workspace/.bazelversion
+++ b/e2e/workspace/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion


### PR DESCRIPTION
5.3.0 breaks e2e/bzlmod so we also pin the e2e tests to 5.2.0 in this PR