### PR TITLE
Move TS config validation to validation output group

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -325,7 +325,6 @@ def ts_project(
             validator = validator,
             **common_kwargs
         )
-        tsc_deps = tsc_deps + ["_validate_%s_options" % name]
 
     typings_out_dir = declaration_dir if declaration_dir else out_dir
     tsbuildinfo_path = ts_build_info_file if ts_build_info_file else name + ".tsbuildinfo"

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -3,20 +3,6 @@
 load("@aspect_rules_js//js:providers.bzl", "JsInfo")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 
-ValidOptionsInfo = provider(
-    doc = "Internal: whether the validator ran successfully",
-    fields = {
-        "marker": """useless file that must be depended on to cause the validation action to run.
-        TODO: replace with https://docs.bazel.build/versions/main/skylark/rules.html#validation-actions""",
-    },
-)
-
-# Targets in deps must provide one or the other of these
-DEPS_PROVIDERS = [
-    [JsInfo],
-    [ValidOptionsInfo],
-]
-
 # Attributes common to all TypeScript rules
 STD_ATTRS = {
     "assets": attr.label_list(
@@ -38,7 +24,7 @@ See more details on the `assets` parameter of the `ts_project` macro.
 
 {downstream_linked_npm_deps}
 """.format(downstream_linked_npm_deps = js_lib_helpers.DOWNSTREAM_LINKED_NPM_DEPS_DOCSTRING),
-        providers = DEPS_PROVIDERS,
+        providers = [JsInfo],
     ),
     "out_dir": attr.string(
         doc = "https://www.typescriptlang.org/tsconfig#outDir",

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -7,7 +7,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//npm:providers.bzl", "NpmPackageStoreInfo")
-load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS", "OUTPUT_ATTRS", "STD_ATTRS", "ValidOptionsInfo", _lib = "lib")
+load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS", "OUTPUT_ATTRS", "STD_ATTRS", _lib = "lib")
 load(":ts_config.bzl", "TsConfigInfo")
 load(":ts_validate_options.bzl", _validate_lib = "lib")
 load(":options.bzl", "OptionsInfo")
@@ -138,8 +138,6 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
         # File 'execroot/aspect_rules_ts/bazel-out/k8-fastbuild/bin/examples/project_references/lib_a/tsconfig.json' not found.
         if ctx.attr.composite and TsConfigInfo in dep:
             transitive_inputs.append(dep[TsConfigInfo].deps)
-        if ValidOptionsInfo in dep:
-            inputs.append(dep[ValidOptionsInfo].marker)
 
     # Gather TsConfig info from both the direct (tsconfig) and indirect (extends) attribute
     tsconfig_inputs = copy_files_to_bin_actions(ctx, _validate_lib.tsconfig_inputs(ctx).to_list())

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -1,7 +1,7 @@
 "Helper rule to check that ts_project attributes match tsconfig.json properties"
 
 load(":ts_config.bzl", "TsConfigInfo")
-load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS", "ValidOptionsInfo")
+load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action", "copy_files_to_bin_actions")
 load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo")
@@ -74,7 +74,7 @@ To disable this check, set the validate attribute to False:
     )
 
     return [
-        ValidOptionsInfo(marker = marker),
+        OutputGroupInfo(_validation = depset([marker])),
     ]
 
 _ATTRS = dict(COMPILER_OPTION_ATTRS, **{

--- a/ts/test/ts_project_test.bzl
+++ b/ts/test/ts_project_test.bzl
@@ -12,10 +12,9 @@ def _dir_test_impl(ctx):
 
     # assert the inputs to the tsc action are what we expect
     action_inputs = target_under_test[OutputGroupInfo]._action_inputs.to_list()
-    asserts.equals(env, 3, len(action_inputs))
+    asserts.equals(env, 2, len(action_inputs))
     asserts.true(env, action_inputs[0].path.find("/dir.ts") != -1)
-    asserts.true(env, action_inputs[1].path.find("/_validate_dir_options.optionsvalid.d.ts") != -1)
-    asserts.true(env, action_inputs[2].path.find("/tsconfig_dir.json") != -1)
+    asserts.true(env, action_inputs[1].path.find("/tsconfig_dir.json") != -1)
 
     # sources should contain the .js output
     sources = target_under_test[JsInfo].sources.to_list()
@@ -55,11 +54,10 @@ def _use_dir_test_impl(ctx):
     # the inputs should *NOT* includes the sources from any deps or transitive deps;
     # only declarations from deps should be included as action inputs.
     action_inputs = target_under_test[OutputGroupInfo]._action_inputs.to_list()
-    asserts.equals(env, 4, len(action_inputs))
+    asserts.equals(env, 3, len(action_inputs))
     asserts.true(env, action_inputs[0].path.find("/dir.d.ts") != -1)
     asserts.true(env, action_inputs[1].path.find("/use_dir.ts") != -1)
-    asserts.true(env, action_inputs[2].path.find("/_validate_use_dir_options.optionsvalid.d.ts") != -1)
-    asserts.true(env, action_inputs[3].path.find("/tsconfig_use_dir.json") != -1)
+    asserts.true(env, action_inputs[2].path.find("/tsconfig_use_dir.json") != -1)
 
     # sources should contain the .js output
     sources = target_under_test[JsInfo].sources.to_list()


### PR DESCRIPTION
Avoid blocking the critical path (typechecking actions) on the validation. Not sure if we have a minimum bazel version we want to support?