### PR TITLE
ci: run PR workflow on main repo and not forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,15 @@ on:
     # Triggers the workflow on push or pull request events but only for the main branch
     push:
         branches: [main]
-    pull_request:
+    pull_request_target:
         branches: [main]
 
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+permissions:
+    contents: read
 
 jobs:
     test:
@@ -57,7 +61,7 @@ jobs:
             - uses: actions/setup-go@v3
               if: ${{ hashFiles(format('{0}/test.sh', matrix.folder)) != '' }}
               with:
-                go-version: '1.17.0'
+                  go-version: '1.17.0'
             - run: go install github.com/bazelbuild/buildtools/buildozer@latest
               if: ${{ hashFiles(format('{0}/test.sh', matrix.folder)) != '' }}
             - name: run ./test.sh


### PR DESCRIPTION
Trying this one from a non-fork. I guess we probably don't need it everywhere so can just close for now though?

🤷 