### PR TITLE
 chore(deps): remove bazel-integration-testing 

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -11,16 +11,6 @@ def rules_ts_internal_deps():
     "Fetch deps needed for local development"
     maybe(
         http_archive,
-        name = "build_bazel_integration_testing",
-        urls = [
-            "https://github.com/bazelbuild/bazel-integration-testing/archive/165440b2dbda885f8d1ccb8d0f417e6cf8c54f17.zip",
-        ],
-        strip_prefix = "bazel-integration-testing-165440b2dbda885f8d1ccb8d0f417e6cf8c54f17",
-        sha256 = "2401b1369ef44cc42f91dc94443ef491208dbd06da1e1e10b702d8c189f098e3",
-    )
-
-    maybe(
-        http_archive,
         name = "io_bazel_rules_go",
         sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
         urls = [


### PR DESCRIPTION
This is from the https://github.com/bazel-contrib/rules-template template but we don't seem to use it.