### PR TITLE
docs: mention --worker_sandboxing incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Since rules_js always runs tools from the bazel-out tree, rules_ts naturally fix
 From the release you wish to use:
 <https://github.com/aspect-build/rules_ts/releases>
 copy the WORKSPACE snippet into your `WORKSPACE` file.
+
+Please note that rules_ts does not work with `--worker_sandboxing` (https://github.com/aspect-build/rules_ts/issues/127).

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ From the release you wish to use:
 <https://github.com/aspect-build/rules_ts/releases>
 copy the WORKSPACE snippet into your `WORKSPACE` file.
 
-Please note that rules_ts does not work with `--worker_sandboxing` (https://github.com/aspect-build/rules_ts/issues/127).
+Please note that rules_ts does not work with `--worker_sandboxing`.


### PR DESCRIPTION
https://github.com/aspect-build/rules_ts/issues/127

It took me a while to figure out which flag (out of dozens) is causing failures when adopting rules_ts into an existing repo, thus I think it'd be better mentioned somewhere.
Feel free to change wording or mentioning `vfs`.