### PR TITLE
fix: validate preserveSymlinks tsconfig option is not set

### DIFF
--- a/ts/private/ts_project_options_validator.js
+++ b/ts/private/ts_project_options_validator.js
@@ -150,6 +150,17 @@ function main(_a) {
         )
         return 1
     }
+    if (options.preserveSymlinks) {
+        console.error(
+            'ERROR: ts_project rule ' +
+                target +
+                " cannot be built because the 'preserveSymlinks' option is set."
+        )
+        console.error(
+            'This is not compatible with ts_project due to the rules_js use of symlinks.'
+        )
+        return 1
+    }
     check('allowJs', 'allow_js')
     check('declarationMap', 'declaration_map')
     check('emitDeclarationOnly', 'emit_declaration_only')


### PR DESCRIPTION
I'm finding this a bit awkward to test because typescript is only fetched from `BUILD.typescript` which isn't really accessible from tests. But every test out there ensures it at least works with valid config, and I've tested the case this is catching manually. @thesayyn I don't understand how you tested workers with such minimal mocking of typescript?