### PR TITLE
fix: validate tsconfig dictionary values

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -325,7 +325,7 @@ def ts_project(
         # user supplied a tsconfig.json InputArtifact
         tsconfig = "tsconfig_%s.json" % name
 
-    elif validate:
+    if validate:
         validate_options(
             name = "_validate_%s_options" % name,
             target = "//%s:%s" % (native.package_name(), name),


### PR DESCRIPTION
CURRENT PR: Just validate to ensure nothing is invalid, tsconfig dict or not: https://github.com/aspect-build/rules_ts/pull/173/commits/0fa1c8f916309923c9adcef3a63430cb83aa9627

Ensure tsconfig dict() and ts_project attributes don't collide: https://github.com/aspect-build/rules_ts/commit/a510a3c29e52566ad6359bbd073dfec3dc3dad7d