### PR TITLE
refactor: TsConfigInfo uses depsets

### DIFF
--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -29,13 +29,13 @@ TsConfigInfo = provider(
 
 def _ts_config_impl(ctx):
     files = [copy_file_to_bin_action(ctx, ctx.file.src)]
-    transitive_deps = []
+    transitive_deps = [depset(copy_files_to_bin_actions(ctx, ctx.files.deps))]
     for dep in ctx.attr.deps:
         if TsConfigInfo in dep:
-            transitive_deps.extend(dep[TsConfigInfo].deps)
+            transitive_deps.append(dep[TsConfigInfo].deps)
     return [
         DefaultInfo(files = depset(files)),
-        TsConfigInfo(deps = files + copy_files_to_bin_actions(ctx, ctx.files.deps) + transitive_deps),
+        TsConfigInfo(deps = depset(files, transitive = transitive_deps)),
     ]
 
 ts_config = rule(

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -8,15 +8,15 @@ def _tsconfig_inputs(ctx):
     """Returns all transitively referenced tsconfig files from "tsconfig" and "extends" attributes."""
     inputs = []
     if TsConfigInfo in ctx.attr.tsconfig:
-        inputs.extend(ctx.attr.tsconfig[TsConfigInfo].deps)
+        inputs.append(ctx.attr.tsconfig[TsConfigInfo].deps)
     else:
-        inputs.append(ctx.file.tsconfig)
+        inputs.append(depset([ctx.file.tsconfig]))
     if hasattr(ctx.attr, "extends") and ctx.attr.extends:
         if TsConfigInfo in ctx.attr.extends:
-            inputs.extend(ctx.attr.extends[TsConfigInfo].deps)
+            inputs.append(ctx.attr.extends[TsConfigInfo].deps)
         else:
-            inputs.extend(ctx.attr.extends.files.to_list())
-    return inputs
+            inputs.append(ctx.attr.extends.files)
+    return depset(transitive = inputs)
 
 def _validate_options_impl(ctx):
     # Bazel won't run our action unless its output is needed, so make a marker file
@@ -43,7 +43,7 @@ def _validate_options_impl(ctx):
 
     ctx.actions.run(
         executable = ctx.executable.validator,
-        inputs = copy_files_to_bin_actions(ctx, inputs),
+        inputs = copy_files_to_bin_actions(ctx, inputs.to_list()),
         outputs = [marker],
         arguments = [arguments],
         mnemonic = "TsValidateOptions",


### PR DESCRIPTION
When we pass to copy_files_to_bin_actions, we're required to convert these to a list, which is too bad. I don't have a big repo handy to run a bazel dump to profile how much memory this actually saves, unlike the contribution to rules_nodejs this is based on: https://github.com/bazelbuild/rules_nodejs/pull/3431

Closes #177