### PR TITLE
fix: allow customizing the npm registry of the core typescript npm packages

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -11,7 +11,7 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 ## rules_ts_dependencies
 
 <pre>
-rules_ts_dependencies(<a href="#rules_ts_dependencies-ts_version_from">ts_version_from</a>, <a href="#rules_ts_dependencies-ts_version">ts_version</a>, <a href="#rules_ts_dependencies-ts_integrity">ts_integrity</a>)
+rules_ts_dependencies(<a href="#rules_ts_dependencies-ts_version_from">ts_version_from</a>, <a href="#rules_ts_dependencies-ts_version">ts_version</a>, <a href="#rules_ts_dependencies-ts_integrity">ts_integrity</a>, <a href="#rules_ts_dependencies-npm_registry">npm_registry</a>)
 </pre>
 
 Dependencies needed by users of rules_ts.
@@ -27,5 +27,6 @@ To skip fetching the typescript package, define repository called `npm_typescrip
 | <a id="rules_ts_dependencies-ts_version_from"></a>ts_version_from |  label of a json file (typically <code>package.json</code>) which declares an exact typescript version in a dependencies or devDependencies property. Exactly one of <code>ts_version</code> or <code>ts_version_from</code> must be set.   |  <code>None</code> |
 | <a id="rules_ts_dependencies-ts_version"></a>ts_version |  version of the TypeScript compiler. Exactly one of <code>ts_version</code> or <code>ts_version_from</code> must be set.   |  <code>None</code> |
 | <a id="rules_ts_dependencies-ts_integrity"></a>ts_integrity |  integrity hash for the npm package. By default, uses values mirrored into rules_ts. For example, to get the integrity of version 4.6.3 you could run <code>curl --silent https://registry.npmjs.org/typescript/4.6.3 | jq -r '.dist.integrity'</code>   |  <code>None</code> |
+| <a id="rules_ts_dependencies-npm_registry"></a>npm_registry |  the npm registry to fetch TypeScript npm packages from   |  <code>"https://registry.npmjs.org"</code> |
 
 

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -3,16 +3,20 @@ See https://bazel.build/docs/bzlmod#extension-definition
 """
 
 load("//ts/private:npm_repositories.bzl", "npm_dependencies")
-load("//ts:repositories.bzl", "LATEST_VERSION")
+load("//ts:repositories.bzl", "DEFAULT_REGISTRY", "LATEST_VERSION")
 
 def _extension_impl(module_ctx):
     for mod in module_ctx.modules:
         for attr in mod.tags.deps:
-            npm_dependencies(ts_version = attr.ts_version, ts_integrity = attr.ts_integrity)
+            npm_dependencies(ts_version = attr.ts_version, ts_integrity = attr.ts_integrity, npm_registry = attr.npm_registry)
 
 ext = module_extension(
     implementation = _extension_impl,
     tag_classes = {
-        "deps": tag_class(attrs = {"ts_version": attr.string(default = LATEST_VERSION), "ts_integrity": attr.string()}),
+        "deps": tag_class(attrs = {
+            "ts_version": attr.string(default = LATEST_VERSION),
+            "ts_integrity": attr.string(),
+            "npm_registry": attr.string(default = DEFAULT_REGISTRY),
+        }),
     },
 )

--- a/ts/private/npm_repositories.bzl
+++ b/ts/private/npm_repositories.bzl
@@ -68,7 +68,7 @@ http_archive_version = repository_rule(
 )
 
 # buildifier: disable=function-docstring
-def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None):
+def npm_dependencies(npm_registry, ts_version_from = None, ts_version = None, ts_integrity = None):
     if (ts_version and ts_version_from) or (not ts_version_from and not ts_version):
         fail("""Exactly one of 'ts_version' or 'ts_version_from' must be set.""")
 
@@ -77,7 +77,7 @@ def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = N
         name = "npm_google_protobuf",
         build_file = "@aspect_rules_ts//ts:BUILD.package",
         integrity = worker_versions.google_protobuf_integrity,
-        urls = ["https://registry.npmjs.org/google-protobuf/-/google-protobuf-{}.tgz".format(worker_versions.google_protobuf_version)],
+        urls = [("%s/google-protobuf/-/google-protobuf-{}.tgz" % npm_registry).format(worker_versions.google_protobuf_version)],
     )
 
     maybe(
@@ -85,7 +85,7 @@ def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = N
         name = "npm_at_bazel_worker",
         integrity = worker_versions.bazel_worker_integrity,
         build_file = "@aspect_rules_ts//ts:BUILD.package",
-        urls = ["https://registry.npmjs.org/@bazel/worker/-/worker-{}.tgz".format(worker_versions.bazel_worker_version)],
+        urls = [("%s/@bazel/worker/-/worker-{}.tgz" % npm_registry).format(worker_versions.bazel_worker_version)],
     )
 
     maybe(
@@ -99,5 +99,5 @@ def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = N
             "bazel_worker_version": worker_versions.bazel_worker_version,
             "google_protobuf_version": worker_versions.google_protobuf_version,
         },
-        urls = ["https://registry.npmjs.org/typescript/-/typescript-{}.tgz"],
+        urls = ["%s/typescript/-/typescript-{}.tgz" % npm_registry],
     )

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -9,7 +9,11 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//ts/private:npm_repositories.bzl", "npm_dependencies")
 load("//ts/private:versions.bzl", TS_VERSIONS = "VERSIONS")
 
+# Default TypeScript version
 LATEST_VERSION = TS_VERSIONS.keys()[-1]
+
+# Default npm registry
+DEFAULT_REGISTRY = "https://registry.npmjs.org"
 
 # WARNING: any additions to this function may be BREAKING CHANGES for users
 # because we'll fetch a dependency which may be different from one that
@@ -17,7 +21,7 @@ LATEST_VERSION = TS_VERSIONS.keys()[-1]
 # ours took precedence. Such breakages are challenging for users, so any
 # changes in this function should be marked as BREAKING in the commit message
 # and released only in semver majors.
-def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None):
+def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None, npm_registry = DEFAULT_REGISTRY):
     """Dependencies needed by users of rules_ts.
 
     To skip fetching the typescript package, define repository called `npm_typescript` before calling this.
@@ -32,6 +36,7 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
             By default, uses values mirrored into rules_ts.
             For example, to get the integrity of version 4.6.3 you could run
             `curl --silent https://registry.npmjs.org/typescript/4.6.3 | jq -r '.dist.integrity'`
+        npm_registry: the npm registry to fetch TypeScript npm packages from
     """
 
     # The minimal version of bazel_skylib we require
@@ -68,4 +73,4 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
         url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.12.1.tar.gz",
     )
 
-    npm_dependencies(ts_version_from = ts_version_from, ts_version = ts_version, ts_integrity = ts_integrity)
+    npm_dependencies(ts_version_from = ts_version_from, ts_version = ts_version, ts_integrity = ts_integrity, npm_registry = npm_registry)


### PR DESCRIPTION
Fixes #191

When a custom npm registry is used the same must be done for the rules_ts npm packages as the rules_js packages. Normally it's done by reading the npmrc file but that isn't available when fetching in the WORKSPACE. Would this be the ideal solution? Ideas?