### PR TITLE
fix: remove unused validate_options(has_local_deps)

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -91,8 +91,8 @@ Implementation rule behind the ts_project macro.
 
 <pre>
 validate_options(<a href="#validate_options-name">name</a>, <a href="#validate_options-allow_js">allow_js</a>, <a href="#validate_options-composite">composite</a>, <a href="#validate_options-declaration">declaration</a>, <a href="#validate_options-declaration_map">declaration_map</a>, <a href="#validate_options-emit_declaration_only">emit_declaration_only</a>,
-                 <a href="#validate_options-extends">extends</a>, <a href="#validate_options-has_local_deps">has_local_deps</a>, <a href="#validate_options-incremental">incremental</a>, <a href="#validate_options-preserve_jsx">preserve_jsx</a>, <a href="#validate_options-resolve_json_module">resolve_json_module</a>, <a href="#validate_options-source_map">source_map</a>,
-                 <a href="#validate_options-target">target</a>, <a href="#validate_options-ts_build_info_file">ts_build_info_file</a>, <a href="#validate_options-tsconfig">tsconfig</a>, <a href="#validate_options-validator">validator</a>)
+                 <a href="#validate_options-extends">extends</a>, <a href="#validate_options-incremental">incremental</a>, <a href="#validate_options-preserve_jsx">preserve_jsx</a>, <a href="#validate_options-resolve_json_module">resolve_json_module</a>, <a href="#validate_options-source_map">source_map</a>, <a href="#validate_options-target">target</a>,
+                 <a href="#validate_options-ts_build_info_file">ts_build_info_file</a>, <a href="#validate_options-tsconfig">tsconfig</a>, <a href="#validate_options-validator">validator</a>)
 </pre>
 
 Validates that some tsconfig.json properties match attributes on ts_project.
@@ -110,7 +110,6 @@ Validates that some tsconfig.json properties match attributes on ts_project.
 | <a id="validate_options-declaration_map"></a>declaration_map |  https://www.typescriptlang.org/tsconfig#declarationMap   | Boolean | optional | False |
 | <a id="validate_options-emit_declaration_only"></a>emit_declaration_only |  https://www.typescriptlang.org/tsconfig#emitDeclarationOnly   | Boolean | optional | False |
 | <a id="validate_options-extends"></a>extends |  https://www.typescriptlang.org/tsconfig#extends   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
-| <a id="validate_options-has_local_deps"></a>has_local_deps |  Whether any of the deps are in the local workspace   | Boolean | optional | False |
 | <a id="validate_options-incremental"></a>incremental |  https://www.typescriptlang.org/tsconfig#incremental   | Boolean | optional | False |
 | <a id="validate_options-preserve_jsx"></a>preserve_jsx |  https://www.typescriptlang.org/tsconfig#jsx   | Boolean | optional | False |
 | <a id="validate_options-resolve_json_module"></a>resolve_json_module |  https://www.typescriptlang.org/tsconfig#resolveJsonModule   | Boolean | optional | False |

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -6,7 +6,7 @@ Differences:
 - didn't copy the whole doc string
 """
 
-load("@aspect_bazel_lib//lib:utils.bzl", "is_external_label", "to_label")
+load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
@@ -342,7 +342,6 @@ def ts_project(
             allow_js = allow_js,
             tsconfig = tsconfig,
             extends = extends,
-            has_local_deps = len([d for d in deps if not is_external_label(d)]) > 0,
             validator = validator,
             **common_kwargs
         )

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -28,7 +28,6 @@ def _validate_options_impl(ctx):
         allow_js = ctx.attr.allow_js,
         declaration = ctx.attr.declaration,
         declaration_map = ctx.attr.declaration_map,
-        has_local_deps = ctx.attr.has_local_deps,
         preserve_jsx = ctx.attr.preserve_jsx,
         composite = ctx.attr.composite,
         emit_declaration_only = ctx.attr.emit_declaration_only,
@@ -57,7 +56,6 @@ def _validate_options_impl(ctx):
     ]
 
 _ATTRS = dict(COMPILER_OPTION_ATTRS, **{
-    "has_local_deps": attr.bool(doc = "Whether any of the deps are in the local workspace"),
     "target": attr.string(),
     "ts_build_info_file": attr.string(),
     "tsconfig": attr.label(mandatory = True, allow_single_file = [".json"]),


### PR DESCRIPTION
This came from rules_nodejs and isn't used in rules_ts.