### PR TITLE
docs: cleanup declaration_dir example

### DIFF
--- a/examples/declaration_dir/BUILD.bazel
+++ b/examples/declaration_dir/BUILD.bazel
@@ -1,3 +1,6 @@
+"""Shows how https://www.typescriptlang.org/tsconfig/#declarationDir can be used to write
+.d.ts typings files to a different folder than the JavaScript outputs."""
+
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_bazel_lib//lib:params_file.bzl", "params_file")
@@ -13,27 +16,30 @@ ts_project(
     source_map = True,
 )
 
+# Convert the types output group to the default output
 filegroup(
     name = "types",
     srcs = [":transpile"],
     output_group = "types",
 )
 
+# Write a manifest file showing all the output locations we wrote to
 params_file(
     name = "params",
-    data = [
-        ":transpile",
-        ":types",
-    ],
+    out = "outputs.txt",
     args = [
         "$(rootpaths :types)",
         "$(rootpaths :transpile)",
     ],
-    out = "outputs.txt"
+    data = [
+        ":transpile",
+        ":types",
+    ],
 )
 
+# Assert that it matches our expectations
 write_source_files(
-    name = "write_params",
+    name = "test",
     files = {
         "expected_outputs.txt": "outputs.txt",
     },

--- a/examples/declaration_dir/dir/lib.ts
+++ b/examples/declaration_dir/dir/lib.ts
@@ -1,0 +1,1 @@
+export const a: string = 'hello'

--- a/examples/declaration_dir/expected_outputs.txt
+++ b/examples/declaration_dir/expected_outputs.txt
@@ -1,0 +1,4 @@
+examples/declaration_dir/out/types/lib.d.ts
+examples/declaration_dir/out/types/lib.d.ts.map
+examples/declaration_dir/out/code/lib.js
+examples/declaration_dir/out/code/lib.js.map

--- a/examples/declaration_dir/tsconfig.json
+++ b/examples/declaration_dir/tsconfig.json
@@ -2,6 +2,6 @@
     "compilerOptions": {
         "sourceMap": true,
         "declaration": true,
-        "declarationMap": true,
+        "declarationMap": true
     }
 }

--- a/examples/declarationdir_with_value/dir/lib.ts
+++ b/examples/declarationdir_with_value/dir/lib.ts
@@ -1,1 +1,0 @@
-export const a: string = 'hello';

--- a/examples/declarationdir_with_value/expected_outputs.txt
+++ b/examples/declarationdir_with_value/expected_outputs.txt
@@ -1,4 +1,0 @@
-examples/declarationdir_with_value/out/types/lib.d.ts
-examples/declarationdir_with_value/out/types/lib.d.ts.map
-examples/declarationdir_with_value/out/code/lib.js
-examples/declarationdir_with_value/out/code/lib.js.map


### PR DESCRIPTION
make the folder name match the typescript compiler option