### PR TITLE
fix: support non-file transpiler srcs

### DIFF
--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -20,13 +20,16 @@ Read more: https://blog.aspect.dev/typescript-speedup
 The `transpiler` attribute of `ts_project` lets you select which tool produces the JavaScript outputs. The default value of `None` means that `tsc` should do transpiling along with type-checking, as this is the simplest configuration without additional dependencies. However as noted above, it's also the slowest.
 
 The `transpiler` attribute accepts a rule or macro with this signature:
-`name, srcs, js_outs, map_outs, **kwargs`
+`name, srcs, **kwargs`
 where the `**kwargs` attribute propagates the tags, visibility, and testonly attributes from `ts_project`.
 
-If you need to pass additional attributes to the transpiler rule, you can use a
+If you need to pass additional attributes to the transpiler rule such as `out_dir`, you can use a
 [partial](https://github.com/bazelbuild/bazel-skylib/blob/main/lib/partial.bzl)
 to bind those arguments at the "make site", then pass that partial to this attribute where it will be called with the remaining arguments.
-
+The transpiler rule or macro is responsible for predicting and declaring outputs.
+If you want to pre-declare the outputs (so that they can be addressed by a Bazel label, like `//path/to:index.js`)
+then you should use a macro which calculates the predicted outputs and supplies them to a `ctx.attr.outputs` attribute
+on the rule.
 See the examples/transpiler directory for a simple example using Babel, or
 <https://github.com/aspect-build/bazel-examples/tree/main/ts_project_transpiler>
 for a more complete example that also shows usage of SWC.

--- a/examples/transpiler/babel.bzl
+++ b/examples/transpiler/babel.bzl
@@ -1,6 +1,5 @@
 "Adapter from the Babel CLI to the ts_project#transpiler interface"
 
-load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//examples:@babel/cli/package_json.bzl", "bin")
 
 # buildifier: disable=function-docstring
@@ -24,6 +23,7 @@ def babel(name, srcs, **kwargs):
         if not src.endswith(".ts"):
             fail("babel example transpiler only supports source .ts files")
 
+        # Predict the output paths where babel will write
         js_out = src.replace(".ts", ".js")
         map_out = src.replace(".ts", ".js.map")
 
@@ -51,8 +51,8 @@ def babel(name, srcs, **kwargs):
         outs.append(js_out)
         outs.append(map_out)
 
-    # The target producing the js files which ts_project() will reference
-    js_library(
+    # The target whose default outputs are the js files which ts_project() will reference
+    native.filegroup(
         name = name,
         srcs = outs,
     )

--- a/examples/transpiler/babel.bzl
+++ b/examples/transpiler/babel.bzl
@@ -1,32 +1,40 @@
 "Adapter from the Babel CLI to the ts_project#transpiler interface"
 
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//examples:@babel/cli/package_json.bzl", "bin")
 
 # buildifier: disable=function-docstring
-def babel(name, srcs, js_outs, map_outs, **kwargs):
+def babel(name, srcs, **kwargs):
     # rules_js runs under the output tree in bazel-out/[arch]/bin
     # and we additionally chdir to the examples/ folder beneath that.
     execroot = "../../../.."
 
-    # In this example we compile each file individually.
+    outs = []
+
+    # In this example we compile each file individually on .ts src files.
+    # The src files must be .ts files known at the loading phase in order
+    # to setup the babel compilation for each .ts file.
+    #
     # You might instead use a single babel_cli call to compile
     # a directory of sources into an output directory,
     # but you'll need to:
     # - make sure the input directory only contains files listed in srcs
     # - make sure the js_outs are actually created in the expected path
     for idx, src in enumerate(srcs):
+        if not src.endswith(".ts"):
+            fail("babel example transpiler only supports source .ts files")
+
+        js_out = src.replace(".ts", ".js")
+        map_out = src.replace(".ts", ".js.map")
+
         # see https://babeljs.io/docs/en/babel-cli
         args = [
             "{}/$(location {})".format(execroot, src),
             "--presets=@babel/preset-typescript",
             "--out-file",
-            "{}/$(location {})".format(execroot, js_outs[idx]),
+            "{}/$(location {})".format(execroot, js_out),
+            "--source-maps",
         ]
-        outs = [js_outs[idx]]
-
-        if len(map_outs) > 0:
-            args.append("--source-maps")
-            outs.append(map_outs[idx])
 
         bin.babel(
             name = "{}_{}".format(name, idx),
@@ -35,7 +43,16 @@ def babel(name, srcs, js_outs, map_outs, **kwargs):
                 "//examples:node_modules/@babel/preset-typescript",
             ],
             chdir = "examples",
-            outs = outs,
+            outs = [js_out, map_out],
             args = args,
             **kwargs
         )
+
+        outs.append(js_out)
+        outs.append(map_out)
+
+    # The target producing the js files which ts_project() will reference
+    js_library(
+        name = name,
+        srcs = outs,
+    )

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -187,7 +187,7 @@ def _out_paths(srcs, out_dir, root_dir, allow_js, ext_map):
                 outs.append(out)
     return outs
 
-def _calculate_js_outs(srcs, out_dir, root_dir, allow_js, preserve_jsx, emit_declaration_only):
+def _calculate_js_outs(srcs, out_dir = ".", root_dir = ".", allow_js = False, preserve_jsx = False, emit_declaration_only = False):
     if emit_declaration_only:
         return []
 
@@ -205,7 +205,7 @@ def _calculate_js_outs(srcs, out_dir, root_dir, allow_js, preserve_jsx, emit_dec
 
     return _out_paths(srcs, out_dir, root_dir, allow_js, exts)
 
-def _calculate_map_outs(srcs, out_dir, root_dir, source_map, preserve_jsx, emit_declaration_only):
+def _calculate_map_outs(srcs, out_dir = ".", root_dir = ".", source_map = True, preserve_jsx = False, emit_declaration_only = False):
     if not source_map or emit_declaration_only:
         return []
 

--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-
 load(":mock_transpiler.bzl", "mock")
 load(":transpiler_tests.bzl", "transpiler_test_suite")
 load("//ts:defs.bzl", "ts_project")
@@ -52,6 +51,15 @@ ts_project(
     tsconfig = _TSCONFIG,
 )
 
+# Ensure the output files are predeclared
+build_test(
+    name = "out_refs_test",
+    targets = [
+        "big.js",
+        "big.d.ts",
+    ],
+)
+
 # This target proves that transpilation doesn't require typechecking:
 #
 # $ bazel build examples/swc:transpile_with_typeerror
@@ -92,13 +100,42 @@ ts_project(
     tsconfig = _TSCONFIG,
 )
 
+# ts_project srcs containing a filegroup()
+write_file(
+    name = "src_filegroup_a",
+    out = "src_fg_a.ts",
+    content = ["export const a: string = \"1\";"],
+)
+
+write_file(
+    name = "src_filegroup_b",
+    out = "src_fg_b.ts",
+    content = ["export const b: string = \"2\";"],
+)
+
+filegroup(
+    name = "src_filegroup",
+    srcs = [
+        "src_fg_a.ts",
+        "src_fg_b.ts",
+    ],
+)
+
+ts_project(
+    name = "transpile_filegroup",
+    srcs = [":src_filegroup"],
+    tags = ["manual"],
+    transpiler = mock,
+    tsconfig = _TSCONFIG,
+)
+
 transpiler_test_suite()
 
 # Ensure that when determining output location, the `root_dir` attribute is only removed once.
 ts_project(
     name = "rootdir_works_with_repeated_directory",
     srcs = ["root/deep/root/deep_src.ts"],
+    root_dir = "root",
     transpiler = mock,
     tsconfig = _TSCONFIG,
-    root_dir = "root",
 )

--- a/ts/test/mock_transpiler.bzl
+++ b/ts/test/mock_transpiler.bzl
@@ -1,26 +1,68 @@
 "Fixture to demonstrate a custom transpiler for ts_project"
 
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
-
 _DUMMY_SOURCEMAP = """{"version":3,"sources":["%s"],"mappings":"AAAO,KAAK,CAAC","file":"in.js","sourcesContent":["fake"]}"""
 
-def mock(name, srcs, js_outs, map_outs, **kwargs):
-    """Mock transpiler macro.
+def _mock_impl(ctx):
+    src_files = [src for src in ctx.files.srcs if src.short_path.endswith(".ts") and not src.short_path.endswith(".d.ts")]
+    out_files = []
 
-    In real usage you would wrap a rule like
-    https://github.com/aspect-build/rules_swc/blob/main/docs/swc.md
-    """
+    for src in src_files:
+        out_path = src.short_path[len(ctx.attr.pkg_dir) + 1:] if src.short_path.startswith(ctx.attr.pkg_dir) else src.short_path
 
-    for i, s in enumerate(srcs):
-        copy_file(
-            name = "_{}_{}_js".format(name, s),
-            src = s,
-            out = js_outs[i],
+        js_file = ctx.actions.declare_file(out_path.replace(".ts", ".js"))
+        map_file = ctx.actions.declare_file(out_path.replace(".ts", ".js.map"))
+
+        out_files.append(js_file)
+        out_files.append(map_file)
+
+        ctx.actions.run_shell(
+            inputs = [src],
+            outputs = [js_file],
+            command = "cp $@",
+            arguments = [src.path, js_file.path.replace(".ts", ".js")],
         )
 
-        write_file(
-            name = "_{}_{}_map".format(name, s),
-            out = map_outs[i],
-            content = [_DUMMY_SOURCEMAP % s],
+        ctx.actions.write(
+            output = map_file,
+            content = _DUMMY_SOURCEMAP % src.short_path,
         )
+
+    return DefaultInfo(files = depset(out_files))
+
+mock_impl = rule(
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "TypeScript source files",
+            allow_files = True,
+            mandatory = True,
+        ),
+
+        # Used only to predeclare outputs
+        "outs": attr.output_list(),
+
+        # TODO: why is this needed?
+        "pkg_dir": attr.string(),
+    },
+    implementation = _mock_impl,
+)
+
+def mock(name, srcs, source_map = False, **kwargs):
+    # Calculate pre-declared outputs so they can be referenced as targets.
+    # This is an optional transpiler feature aligning with the default tsc transpiler.
+    js_outs = [
+        src.replace(".ts", ".js")
+        for src in srcs
+        if (src.endswith(".ts") and not src.endswith(".d.ts"))
+    ]
+    map_outs = [js.replace(".js", ".js.map") for js in js_outs] if source_map else []
+
+    # Run the rule producing those pre-declared outputs as well as any other outputs
+    # which can not be determined ahead of time such as within directories, goruped
+    # within a filegroup() etc.
+    mock_impl(
+        name = name,
+        srcs = srcs,
+        outs = js_outs + map_outs,
+        pkg_dir = native.package_name(),
+        **kwargs
+    )

--- a/ts/test/transpiler_tests.bzl
+++ b/ts/test/transpiler_tests.bzl
@@ -48,7 +48,29 @@ transpile_with_dts_test = unittest.make(_impl2, attrs = {
     "expected_js": attr.string_list(default = ["index.js", "index.js.map"]),
 })
 
+def _impl3(ctx):
+    env = unittest.begin(ctx)
+
+    js_files = []
+    for js in ctx.attr.lib[DefaultInfo].files.to_list():
+        js_files.append(js.basename)
+    asserts.equals(env, ctx.attr.expected_js, sorted(js_files))
+
+    decls = []
+    for decl in ctx.attr.lib[JsInfo].declarations.to_list():
+        decls.append(decl.basename)
+    asserts.equals(env, ctx.attr.expected_declarations, sorted(decls))
+
+    return unittest.end(env)
+
+transitive_filegroup_test = unittest.make(_impl3, attrs = {
+    "lib": attr.label(default = "transpile_filegroup"),
+    "expected_js": attr.string_list(default = ["src_fg_a.js", "src_fg_a.js.map", "src_fg_b.js", "src_fg_b.js.map"]),
+    "expected_declarations": attr.string_list(default = ["src_fg_a.d.ts", "src_fg_b.d.ts"]),
+})
+
 def transpiler_test_suite():
     unittest.suite("t0", transitive_declarations_test)
     unittest.suite("t1", transpile_with_failing_typecheck_test)
     unittest.suite("t2", transpile_with_dts_test)
+    unittest.suite("t3", transitive_filegroup_test)


### PR DESCRIPTION
The current transpiler which takes 3 arrays with aligning indexes is a bad API, and to fix #219 one of those arrays will no longer align with the other 2 making it unusable.

Proposed solution in this PR: https://github.com/aspect-build/rules_ts/issues/219#issuecomment-1309178614

This change makes the transpiler API simply `transpiler(srcs)`. Any additional information required should be added via `partial.make` such as `out_dir`, `source_map` etc. Often these extra params will be required in order to align with the `ts_project` attributes. A macro will almost always be ideal to configure the transpiler including things like aligning these attributes.

swc change to do its own output declarations: https://github.com/aspect-build/rules_swc/commit/f7169623c180bd55aac4f60bc11d879bb83d81d4

[ts/test/mock_transpiler.bzl](https://github.com/aspect-build/rules_ts/pull/236/files#diff-75f4efb350a10f1cde0b94a92e8fea9b83bc39bfad099ccfa9ca31527778c9df) is an example implementing a full rule including support for non-file srcs and predeclaring the .js and .js.map outputs.

[examples/transpiler/babel.bzl](https://github.com/aspect-build/rules_ts/pull/236/files#diff-c4d1b455609d9c2374c64765b2de93cd9a34e615a04603c24bb2ffc22ad00f03) is an example of a macro keeping the same functionality as today where it only supports file inputs. This also predeclares the .js and .js.map outputs as part of the babel invocation.


Alternatives:
* ~~changing `js/map_outs` to maps is a lot nicer then 3 arrays where the indexes align, especially since fixing targets (non-files) in `srcs` breaks the index-aligning. See https://github.com/aspect-build/rules_ts/commit/17a80d5082ca297de23197e7f7ffdb0018eb29fb~~