### PR TITLE
build: turn off ts_project workers in e2e/bzlmod since they are currently broken on Windows and this is tripping the bazel central registry pre-submit test

### DIFF
--- a/e2e/bzlmod/BUILD
+++ b/e2e/bzlmod/BUILD
@@ -4,6 +4,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 ts_project(
     name = "ts",
     srcs = ["foo.ts"],
+    supports_workers = False,
 )
 
 build_test(


### PR DESCRIPTION
The failure on Windows with workers looks non-trivial. At first glance, it looks as tho node is _not_ following symlinks into the virtual store and can't resolve transitive deps.