### PR TITLE
doc: update snippet to suggest ts_version_from

### DIFF
--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -14,9 +14,16 @@ local_repository(
 # you should fetch it *before* calling this.
 # Alternatively, you can skip calling this function, so long as you've
 # already fetched all the dependencies.
-load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION", "rules_ts_dependencies")
+load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
 
-rules_ts_dependencies(ts_version = LATEST_VERSION)
+rules_ts_dependencies(
+    # This keeps the TypeScript version in-sync with the editor, which is typically best.
+    ts_version_from = "//:package.json",
+
+    # Alternatively, you could pick a specific version, or use
+    # load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION")
+    # ts_version = LATEST_VERSION
+)
 
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")

--- a/e2e/workspace/package.json
+++ b/e2e/workspace/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "typescript": "4.8.4"
+    }
+}


### PR DESCRIPTION
It's usually better to keep the typescript version under Bazel synced with what you use outside.

Fixes #256