### PR TITLE
fix: fix cascading rebuilds

### DIFF
--- a/examples/js_lib/BUILD.bazel
+++ b/examples/js_lib/BUILD.bazel
@@ -10,6 +10,8 @@ npm_package(
 
 js_library(
     name = "lib",
-    srcs = ["index.js"],
+    # Provide index.js as declarations available to downstream type checking rules
+    # since it has no corresponding .d.ts file.
+    declarations = ["index.js"],
     visibility = ["//examples:__subpackages__"],
 )

--- a/examples/path_mappings/BUILD.bazel
+++ b/examples/path_mappings/BUILD.bazel
@@ -4,12 +4,6 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 # Example of named modules using tsconfig path mapping instead of
 # rules_js linking.
 
-# Dependencies for all targets in this package
-_DEPS = [
-    "//examples/js_lib:lib",
-    "//examples/dts_lib:lib",
-]
-
 # Type-checks, and emits output to
 # bazel-bin/examples/path_mappings/foo.js
 # bazel-bin/examples/path_mappings/foo.d.ts
@@ -18,7 +12,10 @@ ts_project(
     srcs = ["foo.ts"],
     declaration = True,
     validate = False,
-    deps = _DEPS,
+    deps = [
+        "//examples/dts_lib:lib",
+        "//examples/js_lib:lib",
+    ],
 )
 
 build_test(

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -48,16 +48,17 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "f58d7be1bb0e4b7edb7a0085f969900345f5914e4e647b4f0d2650d5252aa87d",
-        strip_prefix = "rules_js-1.8.0",
-        url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.8.0.tar.gz",
+        # 1.10.0 pre-release that includes https://github.com/aspect-build/rules_js/commit/fba3aad6351d3f8ff577a1d63a01e6ad6da29250
+        # sha256 = "f58d7be1bb0e4b7edb7a0085f969900345f5914e4e647b4f0d2650d5252aa87d",
+        strip_prefix = "rules_js-fba3aad6351d3f8ff577a1d63a01e6ad6da29250",
+        url = "https://github.com/aspect-build/rules_js/archive/fba3aad6351d3f8ff577a1d63a01e6ad6da29250.tar.gz",
     )
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "695d319362b227725e4daa60d863b4d1969b167889902511f1fd3051cea1071f",
-        strip_prefix = "bazel-lib-1.16.3",
-        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.16.3.tar.gz",
+        sha256 = "dee6d20f7c250a3808d601044ea187e41369a544f53f440b3bdafe0a7f53e553",
+        strip_prefix = "bazel-lib-1.17.0",
+        url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.17.0.tar.gz",
     )
 
     npm_dependencies(ts_version_from = ts_version_from, ts_version = ts_version, ts_integrity = ts_integrity)

--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -1,8 +1,11 @@
 load(":mock_transpiler.bzl", "mock")
 load(":transpiler_tests.bzl", "transpiler_test_suite")
+load(":ts_project_test.bzl", "ts_project_test_suite")
 load("//ts:defs.bzl", "ts_project")
 
 transpiler_test_suite()
+
+ts_project_test_suite(name = "ts_project_test")
 
 # Ensure that when determining output location, the `root_dir` attribute is only removed once.
 ts_project(

--- a/ts/test/ts_project_test.bzl
+++ b/ts/test/ts_project_test.bzl
@@ -1,0 +1,150 @@
+"UnitTests for ts_project"
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@aspect_rules_js//js:providers.bzl", "JsInfo")
+load("//ts:defs.bzl", "ts_project")
+
+# dir_test
+def _dir_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    # assert the inputs to the tsc action are what we expect
+    action_inputs = target_under_test[OutputGroupInfo]._action_inputs.to_list()
+    asserts.equals(env, 3, len(action_inputs))
+    asserts.true(env, action_inputs[0].path.find("/dir.ts") != -1)
+    asserts.true(env, action_inputs[1].path.find("/_validate_dir_options.optionsvalid.d.ts") != -1)
+    asserts.true(env, action_inputs[2].path.find("/tsconfig_dir.json") != -1)
+
+    # sources should contain the .js output
+    sources = target_under_test[JsInfo].sources.to_list()
+    asserts.equals(env, 2, len(sources))
+    asserts.true(env, sources[0].path.find("/dir.js") != -1)
+    asserts.true(env, sources[1].path.find("/dir.js.map") != -1)
+
+    # transitive_sources should contain the .js output
+    transitive_sources = target_under_test[JsInfo].transitive_sources.to_list()
+    asserts.equals(env, 2, len(transitive_sources))
+    asserts.true(env, transitive_sources[0].path.find("/dir.js") != -1)
+    asserts.true(env, transitive_sources[1].path.find("/dir.js.map") != -1)
+
+    # declarations should only have the source declarations
+    declarations = target_under_test[JsInfo].declarations.to_list()
+    asserts.equals(env, 1, len(declarations))
+    asserts.true(env, declarations[0].path.find("/dir.d.ts") != -1)
+
+    # transitive_declarations should have the source declarations and transitive declarations
+    transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
+    asserts.equals(env, 1, len(transitive_declarations))
+    asserts.true(env, transitive_declarations[0].path.find("/dir.d.ts") != -1)
+
+    # types OutputGroupInfo should be the same as declarations
+    asserts.equals(env, declarations, target_under_test[OutputGroupInfo].types.to_list())
+
+    return analysistest.end(env)
+
+_dir_test = analysistest.make(_dir_test_impl)
+
+# use_dir_test
+def _use_dir_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    # assert the inputs to the tsc action are what we expect;
+    # the inputs should *NOT* includes the sources from any deps or transitive deps;
+    # only declarations from deps should be included as action inputs.
+    action_inputs = target_under_test[OutputGroupInfo]._action_inputs.to_list()
+    asserts.equals(env, 4, len(action_inputs))
+    asserts.true(env, action_inputs[0].path.find("/dir.d.ts") != -1)
+    asserts.true(env, action_inputs[1].path.find("/use_dir.ts") != -1)
+    asserts.true(env, action_inputs[2].path.find("/_validate_use_dir_options.optionsvalid.d.ts") != -1)
+    asserts.true(env, action_inputs[3].path.find("/tsconfig_use_dir.json") != -1)
+
+    # sources should contain the .js output
+    sources = target_under_test[JsInfo].sources.to_list()
+    asserts.equals(env, 2, len(sources))
+    asserts.true(env, sources[0].path.find("/use_dir.js") != -1)
+    asserts.true(env, sources[1].path.find("/use_dir.js.map") != -1)
+
+    # transitive_sources should contain the .js output
+    transitive_sources = target_under_test[JsInfo].transitive_sources.to_list()
+    asserts.equals(env, 4, len(transitive_sources))
+    asserts.true(env, transitive_sources[0].path.find("/use_dir.js") != -1)
+    asserts.true(env, transitive_sources[1].path.find("/use_dir.js.map") != -1)
+    asserts.true(env, transitive_sources[2].path.find("/dir.js") != -1)
+    asserts.true(env, transitive_sources[3].path.find("/dir.js.map") != -1)
+
+    # declarations should only have the source declarations
+    declarations = target_under_test[JsInfo].declarations.to_list()
+    asserts.equals(env, 1, len(declarations))
+    asserts.true(env, declarations[0].path.find("/use_dir.d.ts") != -1)
+
+    # transitive_declarations should have the source declarations and transitive declarations
+    transitive_declarations = target_under_test[JsInfo].transitive_declarations.to_list()
+    asserts.equals(env, 2, len(transitive_declarations))
+    asserts.true(env, transitive_declarations[0].path.find("/use_dir.d.ts") != -1)
+    asserts.true(env, transitive_declarations[1].path.find("/dir.d.ts") != -1)
+
+    # types OutputGroupInfo should be the same as declarations
+    asserts.equals(env, declarations, target_under_test[OutputGroupInfo].types.to_list())
+
+    return analysistest.end(env)
+
+_use_dir_test = analysistest.make(_use_dir_test_impl)
+
+def ts_project_test_suite(name):
+    """Test suite including all tests and data
+
+    Args:
+        name: Target name of the test_suite target.
+    """
+    _TSCONFIG = {
+        "compilerOptions": {
+            "declaration": True,
+            "sourceMap": True,
+        },
+    }
+
+    write_file(
+        name = "dir_ts",
+        out = "dir.ts",
+        content = ["import { dirname } from 'path'; export const dir = dirname(__filename);"],
+        tags = ["manual"],
+    )
+    ts_project(
+        name = "dir",
+        srcs = ["dir.ts"],
+        tsconfig = _TSCONFIG,
+        tags = ["manual"],
+    )
+    _dir_test(
+        name = "dir_test",
+        target_under_test = "dir",
+    )
+
+    write_file(
+        name = "use_dir_ts",
+        out = "use_dir.ts",
+        content = ["import { dir } from './dir'; export const another_dir = dir;"],
+        tags = ["manual"],
+    )
+    ts_project(
+        name = "use_dir",
+        srcs = ["use_dir.ts"],
+        deps = ["dir"],
+        tsconfig = _TSCONFIG,
+        tags = ["manual"],
+    )
+    _use_dir_test(
+        name = "use_dir_test",
+        target_under_test = "use_dir",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":dir_test",
+            ":use_dir_test",
+        ],
+    )


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_ts/issues/253

BREAKING CHANGE

Sources and transitive source of deps will no longer be added as inputs to the ts_project tsc action. The previous behaviour sub-optimal and unintended as it leads to unnecessary cascading rebuilds when only `.js` files of deps changed. The intended behaviour of ts_project that only declarations are included as inputs to the tsc action.