### PR TITLE
chore: fixup links for new docsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ copy the WORKSPACE snippet into your `WORKSPACE` file.
 
 ## Examples
 
-There are a number of examples in [the examples/ folder](./examples/).
+There are a number of examples in [the examples/ folder](https://github.com/aspect-build/rules_ts/tree/main/examples).
 
 If you'd like an example added, you can file a [Feature Request](https://github.com/aspect-build/rules_ts/issues/new/choose).
 
 ## Usage
 
-See the API documentation in [the docs/ folder](./docs/).
+See the API documentation in [the docs/ folder](https://github.com/aspect-build/rules_ts/tree/main/docs).
 
 ### From a BUILD file
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@
 - `ts_project` always produces some output files, or else Bazel would never run it.
     Therefore you shouldn't use it with TypeScript's `noEmit` option.
     If you only want to test that the code typechecks, use `tsc` directly.
-    See [examples/typecheck_only](/examples/typecheck_only/BUILD.bazel)
+    See [examples/typecheck_only](https://github.com/aspect-build/rules_ts/blob/main/examples/typecheck_only/BUILD.bazel)
 - Your tsconfig settings for `outDir` and `declarationDir` are ignored.
     Bazel requires that the `outDir` (and `declarationDir`) be set beneath
     `bazel-out/[target architecture]/bin/path/to/package`.

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -164,7 +164,7 @@ def ts_project(
             This allows you to use a custom API-compatible compiler in place of the regular `tsc` such as a custom `js_binary` or Angular's `ngc`.
             compatible with it such as Angular's `ngc`.
 
-            See examples of use in [examples/custom_compiler](/examples/custom_compiler/BUILD.bazel)
+            See examples of use in [examples/custom_compiler](https://github.com/aspect-build/rules_ts/blob/main/examples/custom_compiler/BUILD.bazel)
 
         tsc_worker: Label of a custom TypeScript compiler binary which understands Bazel's persistent worker protocol.
         validator: Label of the tsconfig validator to run when `validate = True`.


### PR DESCRIPTION
_API documentation_ link should be updated to https://docs.aspect.build/rules/aspect_rules_ts once the new site launches