### PR TITLE
chore: Add the macOS runner to the matrix strategy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
     test:
         # The type of runner that the job will run on
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
 
         needs:
             - matrix-prep-config
@@ -58,6 +58,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
+                os: [ubuntu-latest, macos-latest]
                 config: ${{ fromJSON(needs.matrix-prep-config.outputs.configs) }}
                 bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
                 folder:


### PR DESCRIPTION
Adds the macOS runner to the matrix strategy of the test workflow job.