### PR TITLE
fix: transitive dependency type checking with transpiler

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -24,5 +24,12 @@ npm_link_package(
     visibility = ["//examples:__subpackages__"],
 )
 
+npm_link_package(
+    name = "node_modules/@myorg/deps_lib_transpiler",
+    src = "//examples/deps_lib_transpiler",
+    root_package = "examples",
+    visibility = ["//examples:__subpackages__"],
+)
+
 # This macro expands to a npm_link_package for each third-party package in package.json
 npm_link_all_packages(name = "node_modules")

--- a/examples/deps_lib_transpiler/BUILD.bazel
+++ b/examples/deps_lib_transpiler/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("//examples/transpiler:babel.bzl", "babel")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = [":__subpackages__"],
+)
+
+ts_project(
+    name = "deps_ts",
+    srcs = ["index.ts"],
+    data = [
+        # Also propagate the date-fns npm package downstream so it is an runtime dependency
+        # of any linked npm_package that this target is used by.
+        "//examples:node_modules/date-fns",
+    ],
+    declaration = True,
+    transpiler = babel,
+    deps = [
+        "//examples:node_modules/date-fns",
+        "//examples/deps_lib_transpiler/b",
+    ],
+)
+
+npm_package(
+    name = "deps_lib_transpiler",
+    srcs = [
+        ":deps_ts",
+    ],
+    package = "@myorg/deps_lib_transpiler",
+    visibility = ["//examples:__subpackages__"],
+)
+
+ts_project(
+    name = "importer_rel_ts",
+    srcs = ["importer_rel.ts"],
+    declaration = True,
+    transpiler = babel,
+    deps = [
+        ":deps_ts",
+    ],
+)
+
+ts_project(
+    name = "importer_linked_ts",
+    srcs = ["importer_linked.ts"],
+    declaration = True,
+    transpiler = babel,
+    deps = [
+        "//examples:node_modules/@myorg/deps_lib_transpiler",
+    ],
+)

--- a/examples/deps_lib_transpiler/b/BUILD.bazel
+++ b/examples/deps_lib_transpiler/b/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("//examples/transpiler:babel.bzl", "babel")
+
+ts_project(
+    name = "b",
+    srcs = ["index.ts"],
+    declaration = True,
+    transpiler = babel,
+    tsconfig = "//examples/deps_lib_transpiler:tsconfig",
+    visibility = ["//examples/deps_lib_transpiler:__subpackages__"],
+)

--- a/examples/deps_lib_transpiler/b/index.ts
+++ b/examples/deps_lib_transpiler/b/index.ts
@@ -1,0 +1,1 @@
+export const b = 'abc'

--- a/examples/deps_lib_transpiler/importer_linked.ts
+++ b/examples/deps_lib_transpiler/importer_linked.ts
@@ -1,0 +1,8 @@
+import { b, format } from '@myorg/deps_lib_transpiler'
+
+export const a: string = `number: 1, date: ${format(
+    new Date(2014, 1, 11),
+    'MM/dd/YYYY'
+)}`
+
+console.log(a, b)

--- a/examples/deps_lib_transpiler/importer_rel.ts
+++ b/examples/deps_lib_transpiler/importer_rel.ts
@@ -1,0 +1,8 @@
+import { b, format } from './index'
+
+export const a: string = `number: 1, date: ${format(
+    new Date(2014, 1, 11),
+    'MM/dd/YYYY'
+)}`
+
+console.log(a, b)

--- a/examples/deps_lib_transpiler/index.ts
+++ b/examples/deps_lib_transpiler/index.ts
@@ -1,0 +1,2 @@
+export { format, formatDistance, formatRelative, subDays } from 'date-fns'
+export { b } from './b'

--- a/examples/deps_lib_transpiler/tsconfig.json
+++ b/examples/deps_lib_transpiler/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "declaration": true
+    }
+}

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -378,6 +378,7 @@ def ts_project(
             # that this js_library can be a valid dep for downstream ts_project or other rules_js derivative rules.
             srcs = [transpile_target_name, tsc_target_name],
             deps = deps,
+            data = data,
             **common_kwargs
         )
 


### PR DESCRIPTION
I'm seeing this at sourcegraph using a transpiler just like this. It seems to be when there is an indirect npm dependency? Or that's my guess at least, I haven't fully investigated that.

The test is the exact same as `deps_lib` but using babel as the transpiler and fails without the fix.