### PR TITLE
release: publish release artifact

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
     "integrity": "**leave this alone**",
     "strip_prefix": "{REPO}-{VERSION}",
-    "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_ts-{TAG}.tar.gz"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
                   # Bazelisk will download bazel to here
                   XDG_CACHE_HOME: ~/.cache/bazel-repo
               run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
-            - name: Prepare workspace snippet
-              run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+            - name: Prepare release
+              run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
             - name: Release
               uses: softprops/action-gh-release@v1
               with:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -7,7 +7,10 @@ set -o errexit -o nounset -o pipefail
 TAG=${GITHUB_REF_NAME}
 # Strip leading 'v'
 PREFIX="rules_ts-${TAG:1}"
-SHA=$(git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip | shasum -a 256 | awk '{print $1}')
+ARCHIVE="rules_ts-$TAG.tar.gz"
+
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF
 ## Using [Bzlmod] with Bazel 6:
@@ -40,7 +43,7 @@ http_archive(
     name = "aspect_rules_ts",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/rules_ts/archive/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/aspect-build/rules_ts/releases/download/${TAG}/${ARCHIVE}",
 )
 EOF
 


### PR DESCRIPTION
GitHub's stability guarantee for the archive is iffy, and we want metrics on downloads. See bazel-contrib/SIG-rules-authors#11 (comment)