### PR TITLE
fix: use full path for tsconfig.json, fix outdir for ts_project

### DIFF
--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -85,12 +85,17 @@ See https://github.com/aspect-build/rules_ts/issues/228 for more details.
     # Add user specified arguments *before* rule supplied arguments
     arguments.add_all(ctx.attr.args)
 
-    outdir = _lib.join(ctx.label.package, ctx.attr.out_dir) if ctx.attr.out_dir else ctx.label.package
+    if ctx.attr.out_dir:
+        outdir = _lib.join(ctx.label.package, ctx.attr.out_dir)
+    elif ctx.label.package:
+        outdir = ctx.label.package
+    else:
+        outdir = ctx.label.workspace_root
     if outdir == "":
         outdir = "."
     arguments.add_all([
         "--project",
-        ctx.file.tsconfig.short_path,
+        ctx.file.tsconfig.path,
         "--outDir",
         outdir,
         "--rootDir",


### PR DESCRIPTION
Hi folks,

We were using TypeScript `nodejs_binary` from the custom rule in another Bazel project. After switching from `rules_nodejs` to `aspect-build/rules_ts`, I found that this use case is now broken.

Specifically, two issues:

1. Where the original `ts_project` rule used `ctx.file.tsconfig.path` [here](https://github.com/bazelbuild/rules_nodejs/blob/4b8bcf2f7c07d2f44a2fa7c6ce1f7431d277f7ed/nodejs/private/ts_project.bzl#L55), the current rule uses `ctx.file.tsconfig.short_path`:

https://github.com/aspect-build/rules_ts/blob/3fee9c2c8cc41d52b29259ee0c3bac16336c8dc8/ts/private/ts_project.bzl#L91-L98

This breaks if the `js_binary` rule that corresponds to that `ts_project` rule is used as an executable from another Bazel project (linebreaks added for readability):

```
ERROR: /path/to/my/homedir/.cache/bazel/_bazel_username/0875673185f3ca7fa2dace5f957ce567/external/typescript_project/BUILD.bazel:9:11:
Compiling TypeScript project @typescript_project//:compile_typescript
[tsc -p ../typescript_project/tsconfig.json] [for tool] failed: (Exit 1):
tsc.sh failed: error executing command (from target @typescript_project//:compile_typescript)
bazel-out/k8-opt-exec-2B5CBBC6/bin/external/npm_typescript/tsc.sh \
  --module esnext --moduleResolution node \
  --project ../typescript_project/tsconfig.json \
  --outDir . --rootDir external/typescript_project

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error TS5058: The specified path does not exist: '../typescript_project/tsconfig.json'.
Target //:do_stuff failed to build
```

(note how it's unable to find `tsconfig.json` where `--project` points to)

2. The `outdir` seems to be broken for this use case, `tsc` does not generate files where Bazel expects them to be.

I made the full repro: https://github.com/alexander-fenster/aspect-ts-repro, it shows the problem and how the suggested fix (from this PR) makes it work.

Thank you!