### PR TITLE
fix: ts_project external workspace builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,8 @@ jobs:
                 folder:
                     - '.'
                     - 'e2e/bzlmod'
+                    - 'e2e/external_dep'
+                    - 'e2e/external_dep/app'
                     - 'e2e/worker'
                     - 'e2e/workspace'
                 exclude:

--- a/e2e/external_dep/.bazelignore
+++ b/e2e/external_dep/.bazelignore
@@ -1,0 +1,2 @@
+app/
+node_modules/

--- a/e2e/external_dep/.bazelrc
+++ b/e2e/external_dep/.bazelrc
@@ -1,0 +1,2 @@
+# import common bazelrc shared with e2e workspaces
+import %workspace%/../../.bazelrc.common

--- a/e2e/external_dep/.bazelversion
+++ b/e2e/external_dep/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/external_dep/BUILD
+++ b/e2e/external_dep/BUILD
@@ -1,0 +1,16 @@
+"""Tests a `ts_project()` in one workspace being used in another."""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_project(
+    name = "lib",
+    srcs = ["lib.ts"],
+    declaration = True,
+    visibility = ["//visibility:public"],
+)
+
+build_test(
+    name = "test",
+    targets = [":lib"],
+)

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -1,0 +1,29 @@
+workspace(name = "lib_wksp")
+
+local_repository(
+    name = "aspect_rules_ts",
+    path = "../..",
+)
+
+load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION", "rules_ts_dependencies")
+rules_ts_dependencies(ts_version = LATEST_VERSION)
+
+# Fetch and register node, if you haven't already
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "node",
+    node_version = DEFAULT_NODE_VERSION,
+)
+
+load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
+
+npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+
+load("@npm//:repositories.bzl", "npm_repositories")
+
+npm_repositories()

--- a/e2e/external_dep/app/.bazelignore
+++ b/e2e/external_dep/app/.bazelignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/e2e/external_dep/app/.bazelrc
+++ b/e2e/external_dep/app/.bazelrc
@@ -1,0 +1,2 @@
+# import common bazelrc shared with e2e workspaces
+import %workspace%/../../../.bazelrc.common

--- a/e2e/external_dep/app/.bazelversion
+++ b/e2e/external_dep/app/.bazelversion
@@ -1,0 +1,1 @@
+../../../.bazelversion

--- a/e2e/external_dep/app/BUILD
+++ b/e2e/external_dep/app/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+# `ts_project()` should be able to build from the non-main workspace.
+build_test(
+    name = "test",
+    targets = ["@lib_wksp//:lib"],
+)

--- a/e2e/external_dep/app/WORKSPACE
+++ b/e2e/external_dep/app/WORKSPACE
@@ -1,0 +1,31 @@
+local_repository(
+    name = "aspect_rules_ts",
+    path = "../../..",
+)
+local_repository(
+    name = "lib_wksp",
+    path = "..",
+)
+
+load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION", "rules_ts_dependencies")
+rules_ts_dependencies(ts_version = LATEST_VERSION)
+
+# Fetch and register node, if you haven't already
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "node",
+    node_version = DEFAULT_NODE_VERSION,
+)
+
+load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
+
+npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
+)
+
+load("@npm//:repositories.bzl", "npm_repositories")
+
+npm_repositories()

--- a/e2e/external_dep/app/package.json
+++ b/e2e/external_dep/app/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "typescript": "4.8.4"
+    }
+}

--- a/e2e/external_dep/app/pnpm-lock.yaml
+++ b/e2e/external_dep/app/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: 5.4
+
+specifiers:
+  typescript: 4.8.4
+
+devDependencies:
+  typescript: 4.8.4
+
+packages:
+
+  /typescript/4.8.4:
+    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true

--- a/e2e/external_dep/lib.ts
+++ b/e2e/external_dep/lib.ts
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/e2e/external_dep/package.json
+++ b/e2e/external_dep/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "typescript": "4.8.4"
+    }
+}

--- a/e2e/external_dep/pnpm-lock.yaml
+++ b/e2e/external_dep/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: 5.4
+
+specifiers:
+  typescript: 4.8.4
+
+devDependencies:
+  typescript: 4.8.4
+
+packages:
+
+  /typescript/4.8.4:
+    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true

--- a/e2e/external_dep/tsconfig.json
+++ b/e2e/external_dep/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+  },
+}


### PR DESCRIPTION
Fixes #284.

`short_path` is not sufficient to handle external paths and we need to strip `ctx.bin_dir.path` instead. This updates the `ts_project()` rules as well as adds a regression test which triggers a `ts_project()` target to build from the context of an external workspace.