### PR TITLE
feat: add JsInfo provider to ts_config rule

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,3 +3,5 @@ bazel-output-base
 examples/node_modules
 examples/linked/node_modules
 examples/linked_consumer/node_modules
+examples/linked_tsconfig/node_modules
+examples/linked_tsconfig_consumer/node_modules

--- a/examples/linked_tsconfig/BUILD.bazel
+++ b/examples/linked_tsconfig/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+
+npm_link_all_packages()
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    deps = [
+        ":node_modules/@tsconfig/node18",
+    ],
+)
+
+npm_package(
+    name = "linked_tsconfig",
+    srcs = [":tsconfig"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/linked_tsconfig/package.json
+++ b/examples/linked_tsconfig/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "@lib/tsconfig",
+    "private": true,
+    "dependencies": {
+        "@tsconfig/node18": "1.0.1"
+    }
+}

--- a/examples/linked_tsconfig/tsconfig.json
+++ b/examples/linked_tsconfig/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "@tsconfig/node18/tsconfig.json"
+}

--- a/examples/linked_tsconfig_consumer/BUILD.bazel
+++ b/examples/linked_tsconfig_consumer/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+npm_link_all_packages()
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    deps = [
+        ":node_modules/@lib/tsconfig",
+    ],
+)
+
+ts_project(
+    name = "lib",
+    srcs = [
+        "index.ts",
+    ],
+    tsconfig = ":tsconfig",
+    deps = [
+        ":node_modules/@types/node",
+    ],
+)

--- a/examples/linked_tsconfig_consumer/index.ts
+++ b/examples/linked_tsconfig_consumer/index.ts
@@ -1,0 +1,1 @@
+console.log('hello world')

--- a/examples/linked_tsconfig_consumer/package.json
+++ b/examples/linked_tsconfig_consumer/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "devDependencies": {
+        "@lib/tsconfig": "workspace:*",
+        "@types/node": "18.13.0"
+    }
+}

--- a/examples/linked_tsconfig_consumer/tsconfig.json
+++ b/examples/linked_tsconfig_consumer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "//": "the hacky path below is required because while @lib/tsconfig/tsconfig.json _will_ resolve, tsc won't follow the symlink into the virtual store so the transitive npm dep of @lib/tsconfig on @tsconfig/node18/tsconfig.json won't be resolvable",
+    "extends": "../node_modules/.aspect_rules_js/@lib+tsconfig@0.0.0/node_modules/@lib/tsconfig/tsconfig.json"
+}

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -53,6 +53,20 @@ importers:
     dependencies:
       '@lib/test': link:../linked
 
+  linked_tsconfig:
+    specifiers:
+      '@tsconfig/node18': 1.0.1
+    dependencies:
+      '@tsconfig/node18': 1.0.1
+
+  linked_tsconfig_consumer:
+    specifiers:
+      '@lib/tsconfig': workspace:*
+      '@types/node': 18.13.0
+    devDependencies:
+      '@lib/tsconfig': link:../linked_tsconfig
+      '@types/node': 18.13.0
+
 packages:
 
   /@ampproject/remapping/2.2.0:
@@ -493,6 +507,10 @@ packages:
 
   /@tsconfig/node16-strictest-esm/1.0.3:
     resolution: {integrity: sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==}
+    dev: false
+
+  /@tsconfig/node18/1.0.1:
+    resolution: {integrity: sha512-sNFeK6X2ATlhlvzyH4kKYQlfHXE2f2/wxtB9ClvYXevWpmwkUT7VaSrjIN9E76Qebz8qP5JOJJ9jD3QoD/Z9TA==}
     dev: false
 
   /@types/jasmine/4.3.0:

--- a/examples/pnpm-workspace.yaml
+++ b/examples/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
     - linked
     - linked_consumer
+    - linked_tsconfig
+    - linked_tsconfig_consumer

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -17,6 +17,7 @@
 load("@aspect_bazel_lib//lib:paths.bzl", "relative_file")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action", "copy_files_to_bin_actions")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
+load("@aspect_rules_js//js:providers.bzl", "js_info")
 load(":ts_lib.bzl", _lib = "lib")
 
 TsConfigInfo = provider(
@@ -30,6 +31,7 @@ TsConfigInfo = provider(
 
 def _ts_config_impl(ctx):
     files = [copy_file_to_bin_action(ctx, ctx.file.src)]
+
     transitive_deps = [
         depset(copy_files_to_bin_actions(ctx, ctx.files.deps)),
         js_lib_helpers.gather_files_from_js_providers(
@@ -37,14 +39,55 @@ def _ts_config_impl(ctx):
             include_transitive_sources = True,
             include_declarations = True,
             include_npm_linked_packages = True,
-        )
+        ),
     ]
 
+    # TODO: now that ts_config.bzl provides a JsInfo, we should be able to remove TsConfigInfo in the future
+    # since transitive files will now be passed through transitive_declarations in JsInfo
     for dep in ctx.attr.deps:
         if TsConfigInfo in dep:
             transitive_deps.append(dep[TsConfigInfo].deps)
+
+    transitive_sources = js_lib_helpers.gather_transitive_sources([], ctx.attr.deps)
+
+    transitive_declarations = js_lib_helpers.gather_transitive_declarations(files, ctx.attr.deps)
+
+    npm_linked_packages = js_lib_helpers.gather_npm_linked_packages(
+        srcs = [],
+        deps = ctx.attr.deps,
+    )
+
+    npm_package_store_deps = js_lib_helpers.gather_npm_package_store_deps(
+        targets = ctx.attr.deps,
+    )
+
+    files_depset = depset(files)
+
+    runfiles = js_lib_helpers.gather_runfiles(
+        ctx = ctx,
+        sources = depset(),  # tsconfig.json file won't be needed at runtime
+        data = [],
+        deps = ctx.attr.deps,
+    )
+
     return [
-        DefaultInfo(files = depset(files)),
+        DefaultInfo(
+            files = files_depset,
+            runfiles = runfiles,
+        ),
+        js_info(
+            # provide tsconfig.json file via `declarations` and not `sources` since they are only needed
+            # for downstream ts_project rules and not in downstream runtime binary rules
+            declarations = files_depset,
+            npm_linked_package_files = npm_linked_packages.direct_files,
+            npm_linked_packages = npm_linked_packages.direct,
+            npm_package_store_deps = npm_package_store_deps,
+            sources = depset(),
+            transitive_declarations = transitive_declarations,
+            transitive_npm_linked_package_files = npm_linked_packages.transitive_files,
+            transitive_npm_linked_packages = npm_linked_packages.transitive,
+            transitive_sources = transitive_sources,
+        ),
         TsConfigInfo(deps = depset(files, transitive = transitive_deps)),
     ]
 

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -218,7 +218,7 @@ This is an error because Bazel does not run actions unless their outputs are nee
     if len(outputs) > 0:
         inputs_depset = depset(
             copy_files_to_bin_actions(ctx, inputs),
-            transitive = transitive_inputs + [_gather_declarations_from_js_providers(ctx.attr.srcs + ctx.attr.deps)],
+            transitive = transitive_inputs + [_gather_declarations_from_js_providers(ctx.attr.srcs + [ctx.attr.tsconfig] + ctx.attr.deps)],
         )
 
         ctx.actions.run(
@@ -237,12 +237,12 @@ This is an error because Bazel does not run actions unless their outputs are nee
             },
         )
 
-    transitive_sources = js_lib_helpers.gather_transitive_sources(output_sources, ctx.attr.srcs + ctx.attr.deps)
+    transitive_sources = js_lib_helpers.gather_transitive_sources(output_sources, ctx.attr.srcs + [ctx.attr.tsconfig] + ctx.attr.deps)
 
-    transitive_declarations = js_lib_helpers.gather_transitive_declarations(output_declarations, ctx.attr.srcs + ctx.attr.deps)
+    transitive_declarations = js_lib_helpers.gather_transitive_declarations(output_declarations, ctx.attr.srcs + [ctx.attr.tsconfig] + ctx.attr.deps)
 
     npm_linked_packages = js_lib_helpers.gather_npm_linked_packages(
-        srcs = ctx.attr.srcs,
+        srcs = ctx.attr.srcs + [ctx.attr.tsconfig],
         deps = ctx.attr.deps,
     )
 
@@ -257,7 +257,7 @@ This is an error because Bazel does not run actions unless their outputs are nee
         ctx = ctx,
         sources = output_sources_depset,
         data = ctx.attr.data,
-        deps = ctx.attr.srcs + ctx.attr.deps,
+        deps = ctx.attr.srcs + [ctx.attr.tsconfig] + ctx.attr.deps,
     )
 
     providers = [


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_ts/issues/271 although it looks like there is additional speed bump that `tsc` doesn't follow the symlinked to the virtual store location of its `extends` so transitive npm deps of an `extends` can't be resolved. I suspect this is easily reproducible outside of Bazel when `hoist = False` in `.npmrc`.

See comment left in `examples/linked_tsconfig_consumer/tsconfig.json` for more info: 

```
{
    "//": "the hacky path below is required because while @lib/tsconfig/tsconfig.json _will_ resolve, tsc won't follow the symlink into the virtual store so the transitive npm dep of @lib/tsconfig on @tsconfig/node18/tsconfig.json won't be resolvable",
    "extends": "../node_modules/.aspect_rules_js/@lib+tsconfig@0.0.0/node_modules/@lib/tsconfig/tsconfig.json"
}
```

There are other way this could be worked around including manually propagating the dependency to downstream ts_project targets but the hacky virtual store path work-around above seems the simplest; here we just abandon the standard node_modules resolution algorithm that would incorrectly resolve to `node_modules/@lib/tsconfig/tsconfig.json` from where transitive npm deps of `@lib/tsconfig` would not be resolvable unless they were elsewhere on the node_modules resolution path such as `node_modules/my_transitive_dep`. The downside of this work-around is that would not work outside of Bazel with the same tsconfig file since under pnpm the virtual store path would be different.

@Toxaris There is a follow-up task here of reproducing the issue with tsc outside of Bazel and filing an issue to the typescript repo but I've got too many other things on my plate atm so I'm going to punt on that. If you wanted to make the repro and file an issue upstream I bet the fix is a relatively straight forward one in typescript.