### PR TITLE
refactor: consider json a js source (if resolve_json_module)

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -345,7 +345,7 @@ def ts_project(
     tsc_js_outs = []
     tsc_map_outs = []
     if not transpiler:
-        tsc_js_outs = _lib.calculate_js_outs(srcs, out_dir, root_dir, allow_js, preserve_jsx, emit_declaration_only)
+        tsc_js_outs = _lib.calculate_js_outs(srcs, out_dir, root_dir, allow_js, resolve_json_module, preserve_jsx, emit_declaration_only)
         tsc_map_outs = _lib.calculate_map_outs(srcs, out_dir, root_dir, source_map, preserve_jsx, emit_declaration_only)
         tsc_target_name = name
     else:
@@ -412,6 +412,7 @@ def ts_project(
         deps = tsc_deps,
         tsconfig = tsconfig,
         allow_js = allow_js,
+        resolve_json_module = resolve_json_module,
         extends = extends,
         incremental = incremental,
         preserve_jsx = preserve_jsx,

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -118,7 +118,7 @@ def _filter_input_files(files, allow_js, resolve_json_module):
         f
         for f in files
         # include typescript, json & declaration sources
-        if _lib.is_ts_src(f.basename, allow_js) or _lib.is_json_src(f.basename, resolve_json_module) or _lib.is_typings_src(f.basename)
+        if _lib.is_ts_src(f.basename, allow_js, resolve_json_module) or _lib.is_typings_src(f.basename)
     ]
 
 def _write_tsconfig_rule(ctx):


### PR DESCRIPTION
This allows us to use the _out_paths machinery for json sources as well.

To achieve this, we add a resolve_json_module parameter to relevant methods in ts_lib (ts_lib is private so this is a backwards compatible change).

There are two small side-effects to this refactor:
- We use _lib.relative_to_package rather than a prefix removal.
- json inputs that are not sources and do not have an input / output collision are now declared.