### PR TITLE
feat: skipLibCheck take 2

### DIFF
--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,42 +1,34 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
 )
 
-# Users can enable with --@aspect_rules_ts//ts:skipLibCheck
-bool_flag(
+# Users can enable with --@aspect_rules_ts//ts:skipLibCheck=always
+string_flag(
     # Note: this name is chosen to be searchable when users look for "skipLibCheck" in their repo,
     # as that's the way it appears in tsconfig.json or tsc command line.
     name = "skipLibCheck",
-    build_setting_default = False,
-)
-
-# Users can enable with --@aspect_rules_ts//ts:use_skipLibCheck_from_tsconfig
-bool_flag(
-    name = "use_skipLibCheck_from_tsconfig",
-    build_setting_default = False,
+    # TODO(2.0): change default to "unspecified"
+    build_setting_default = "honor_tsconfig",
+    values = [
+        "always",
+        "honor_tsconfig",
+        "unspecified",
+    ],
 )
 
 # Note, users could use a Transition to make a subgraph of their depgraph opt-in to skipLibCheck.
 config_setting(
     name = "skip_lib_check.always",
-    # Note: check both values to ensure they are mutually exclusive, not both set.
-    flag_values = {
-        ":skipLibCheck": "1",
-        ":use_skipLibCheck_from_tsconfig": "0",
-    },
+    flag_values = {":skipLibCheck": "always"},
 )
 
 config_setting(
     name = "skip_lib_check.honor_tsconfig",
-    # Again, check that they are mutually exclusive.
-    flag_values = {
-        ":skipLibCheck": "0",
-        ":use_skipLibCheck_from_tsconfig": "1",
-    },
+    flag_values = {":skipLibCheck": "honor_tsconfig"},
 )
 
 bzl_library(

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,8 +1,31 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
 
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
+)
+
+# Enable with --@aspect_rules_ts//ts:skip_lib_check=1
+int_flag(
+    name = "skip_lib_check",
+    # Default is 0 to be a non-breaking change in rules_ts 1.x
+    # TODO(2.0): change default to -1 so we require users to consider which value of the flag is best.
+    build_setting_default = 0,
+)
+
+config_setting(
+    name = "skip_lib_check_honor_tsconfig",
+    flag_values = {
+        ":skip_lib_check": "0",
+    },
+)
+
+config_setting(
+    name = "skip_lib_check_always",
+    flag_values = {
+        ":skip_lib_check": "1",
+    },
 )
 
 bzl_library(

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,30 +1,41 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "int_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
 )
 
-# Enable with --@aspect_rules_ts//ts:skip_lib_check=1
-int_flag(
-    name = "skip_lib_check",
-    # Default is 0 to be a non-breaking change in rules_ts 1.x
-    # TODO(2.0): change default to -1 so we require users to consider which value of the flag is best.
-    build_setting_default = 0,
+# Users can enable with --@aspect_rules_ts//ts:skipLibCheck
+bool_flag(
+    # Note: this name is chosen to be searchable when users look for "skipLibCheck" in their repo,
+    # as that's the way it appears in tsconfig.json or tsc command line.
+    name = "skipLibCheck",
+    build_setting_default = False,
 )
 
+# Users can enable with --@aspect_rules_ts//ts:use_skipLibCheck_from_tsconfig
+bool_flag(
+    name = "use_skipLibCheck_from_tsconfig",
+    build_setting_default = False,
+)
+
+# Note, users could use a Transition to make a subgraph of their depgraph opt-in to skipLibCheck.
 config_setting(
-    name = "skip_lib_check_honor_tsconfig",
+    name = "skip_lib_check.always",
+    # Note: check both values to ensure they are mutually exclusive, not both set.
     flag_values = {
-        ":skip_lib_check": "0",
+        ":skipLibCheck": "1",
+        ":use_skipLibCheck_from_tsconfig": "0",
     },
 )
 
 config_setting(
-    name = "skip_lib_check_always",
+    name = "skip_lib_check.honor_tsconfig",
+    # Again, check that they are mutually exclusive.
     flag_values = {
-        ":skip_lib_check": "1",
+        ":skipLibCheck": "0",
+        ":use_skipLibCheck_from_tsconfig": "1",
     },
 )
 

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -433,8 +433,8 @@ def ts_project(
         srcs = srcs,
         args = args + select(
             {
-                "@rules_ts//ts:skip_lib_check.always": ["--skipLibCheck"],
-                "//ts:skip_lib_check.honor_tsconfig": [],
+                "@aspect_rules_ts//ts:skip_lib_check.always": ["--skipLibCheck"],
+                "@aspect_rules_ts//ts:skip_lib_check.honor_tsconfig": [],
             },
             no_match_error = _skip_lib_check_selection_required,
         ),

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -433,7 +433,7 @@ def ts_project(
         srcs = srcs,
         args = args + select(
             {
-                "//ts:skip_lib_check.always": ["--skipLibCheck"],
+                "@rules_ts//ts:skip_lib_check.always": ["--skipLibCheck"],
                 "//ts:skip_lib_check.honor_tsconfig": [],
             },
             no_match_error = _skip_lib_check_selection_required,

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -37,12 +37,12 @@ You must choose exactly one of the following flags:
 1. To choose the faster performance, put this in /.bazelrc:
 
     # passes an argument `--skipLibCheck` to *every* spawn of tsc
-    build --@aspect_rules_ts//ts:skipLibCheck
+    build --@aspect_rules_ts//ts:skipLibCheck=always
 
 2. To choose more correct typechecks, put this in /.bazelrc:
 
     # honor the setting of `skipLibCheck` in the tsconfig.json file
-    build --@aspect_rules_ts//ts:use_skipLibCheck_from_tsconfig
+    build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 
 ##########################################################
 """
@@ -435,9 +435,6 @@ def ts_project(
             {
                 "//ts:skip_lib_check.always": ["--skipLibCheck"],
                 "//ts:skip_lib_check.honor_tsconfig": [],
-                # TODO(2.0): remove the default so users are forced to
-                # make a conscious choice between speed and correctness.
-                "//conditions:default": [],
             },
             no_match_error = _skip_lib_check_selection_required,
         ),

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -16,6 +16,24 @@ load("//ts/private:ts_lib.bzl", _lib = "lib")
 ts_config = _ts_config
 TsConfigInfo = _TsConfigInfo
 
+# TODO(2.0): fill in more docs
+_skip_lib_check_selection_required = """
+
+######## Required Typecheck Performance Selection ########
+TODO: describe
+
+This can save time during compilation at the expense of type-system accuracy. 
+For example, two libraries could define two copies of the same type in an inconsistent way. 
+Rather than doing a full check of all d.ts files, TypeScript will type check the code you specifically refer to in your app's source code.
+
+To select skipLibCheck, put this in /.bazelrc:
+xxx
+
+To choose slower but more correct typechecks, put this in /.bazelrc:
+yyy
+##########################################################
+"""
+
 validate_options = rule(
     doc = """Validates that some tsconfig.json properties match attributes on ts_project.
     See the documentation of [`ts_project`](#ts_project) for more information.""",
@@ -400,7 +418,13 @@ def ts_project(
     ts_project_rule(
         name = tsc_target_name,
         srcs = srcs,
-        args = args,
+        args = args + select(
+            {
+                "//ts:skip_lib_check_always": ["--skipLibCheck"],
+                "//ts:skip_lib_check_honor_tsconfig": [],
+            },
+            no_match_error = _skip_lib_check_selection_required,
+        ),
         assets = assets,
         data = data,
         deps = tsc_deps,


### PR DESCRIPTION
Here's the DX of what the `select` failure message looks like, will be live for 2.0 under this proposal:

```
$ bazel build examples/simple:ts --strategy=TsProject=sandboxed -s
ERROR: /home/alexeagle/Projects/rules_ts/examples/simple/BUILD.bazel:9:11: configurable attribute "args" in //examples/simple:ts doesn't match this configuration: 

######## Required Typecheck Performance Selection ########

TypeScript's type-checking exposes a flag `--skipLibCheck`:
https://www.typescriptlang.org/tsconfig#skipLibCheck

Using this flag saves substantial time during type-checking.
Rather than doing a full check of all d.ts files, TypeScript will only type-check the code you
specifically refer to in your app's source code.
We recommend this for most rules_ts users.

HOWEVER this performance improvement comes at the expense of type-system accuracy. 
For example, two packages could define two copies of the same type in an inconsistent way.
If you publish a library from your repository, your incorrect types may result in errors for your users.

You must choose exactly one of the following flags:

1. To choose the faster performance, put this in /.bazelrc:

    # passes an argument `--skipLibCheck` to *every* spawn of tsc
    build --@aspect_rules_ts//ts:skipLibCheck=always

2. To choose more correct typechecks, put this in /.bazelrc:

    # honor the setting of `skipLibCheck` in the tsconfig.json file
    build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig

##########################################################

This instance of //examples/simple:ts has configuration identifier 1cd096f. To inspect its configuration, run: bazel config 1cd096f.

For more help, see https://bazel.build/docs/configurable-attributes#faq-select-choose-condition.

ERROR: Analysis of target '//examples/simple:ts' failed; build aborted: 
INFO: Elapsed time: 0.095s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (1 packages loaded, 0 targets configured)
```

Fixes #348 