### PR TITLE
examples: add tsconfig types example

### DIFF
--- a/examples/tsconfig_types/BUILD.bazel
+++ b/examples/tsconfig_types/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_config(
+    name = "config",
+    src = "tsconfig.json",
+    deps = [
+        "types/typings.d.ts",
+        "//examples:node_modules/@types/node",
+    ],
+)
+
+ts_project(
+    name = "ts",
+    srcs = [
+        "index.ts",
+    ],
+    tsconfig = ":config",
+)
+
+build_test(
+    name = "test",
+    targets = [":ts"],
+)

--- a/examples/tsconfig_types/index.ts
+++ b/examples/tsconfig_types/index.ts
@@ -1,0 +1,3 @@
+import css from './styles.css'
+
+console.log(__dirname, css)

--- a/examples/tsconfig_types/tsconfig.json
+++ b/examples/tsconfig_types/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "types": ["node", "./types/typings"]
+    }
+}

--- a/examples/tsconfig_types/types/typings.d.ts
+++ b/examples/tsconfig_types/types/typings.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+    const cssModule: string
+    export default cssModule
+}


### PR DESCRIPTION
Just a basic example/test of `ts_config` deps. The `compilerOptions.types` having no `.d.ts` file extension was a surprise to me which I first assumed was a `ts_config` deps bug but this example shows it working.