### PR TITLE
refactor: rename LATEST_VERSION to LATEST_TYPESCRIPT_VERSION

### DIFF
--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -5,8 +5,9 @@ local_repository(
     path = "../..",
 )
 
-load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION", "rules_ts_dependencies")
-rules_ts_dependencies(ts_version = LATEST_VERSION)
+load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")
+
+rules_ts_dependencies(ts_version = LATEST_TYPESCRIPT_VERSION)
 
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")

--- a/e2e/external_dep/app/WORKSPACE
+++ b/e2e/external_dep/app/WORKSPACE
@@ -2,13 +2,15 @@ local_repository(
     name = "aspect_rules_ts",
     path = "../../..",
 )
+
 local_repository(
     name = "lib_wksp",
     path = "..",
 )
 
-load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION", "rules_ts_dependencies")
-rules_ts_dependencies(ts_version = LATEST_VERSION)
+load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")
+
+rules_ts_dependencies(ts_version = LATEST_TYPESCRIPT_VERSION)
 
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -21,8 +21,8 @@ rules_ts_dependencies(
     ts_version_from = "//:package.json",
 
     # Alternatively, you could pick a specific version, or use
-    # load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_VERSION")
-    # ts_version = LATEST_VERSION
+    # load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION")
+    # ts_version = LATEST_TYPESCRIPT_VERSION
 )
 
 # Fetch and register node, if you haven't already

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -3,7 +3,7 @@ See https://bazel.build/docs/bzlmod#extension-definition
 """
 
 load("//ts/private:npm_repositories.bzl", "npm_dependencies")
-load("//ts:repositories.bzl", "LATEST_VERSION")
+load("//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION")
 
 def _extension_impl(module_ctx):
     for mod in module_ctx.modules:
@@ -13,6 +13,6 @@ def _extension_impl(module_ctx):
 ext = module_extension(
     implementation = _extension_impl,
     tag_classes = {
-        "deps": tag_class(attrs = {"ts_version": attr.string(default = LATEST_VERSION), "ts_integrity": attr.string()}),
+        "deps": tag_class(attrs = {"ts_version": attr.string(default = LATEST_TYPESCRIPT_VERSION), "ts_integrity": attr.string()}),
     },
 )

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -8,7 +8,10 @@ load("//ts/private:maybe.bzl", http_archive = "maybe_http_archive")
 load("//ts/private:npm_repositories.bzl", "npm_dependencies")
 load("//ts/private:versions.bzl", "TOOL_VERSIONS")
 
-LATEST_VERSION = TOOL_VERSIONS.keys()[-1]
+LATEST_TYPESCRIPT_VERSION = TOOL_VERSIONS.keys()[-1]
+
+# TODO(2.0): remove this alias
+LATEST_VERSION = LATEST_TYPESCRIPT_VERSION
 
 # WARNING: any additions to this function may be BREAKING CHANGES for users
 # because we'll fetch a dependency which may be different from one that


### PR DESCRIPTION
Fix https://github.com/aspect-build/rules_js/issues/817

WDYT of changing this in 2.0+? Could add it as an alias for now...