### PR TITLE
fix: ts_project macro creates same-named rule

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -9,7 +9,7 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")
-load("//ts/private:ts_project.bzl", _ts_project_lib = "ts_project")
+load("//ts/private:ts_project.bzl", _ts_project = "ts_project")
 load("//ts/private:ts_validate_options.bzl", validate_lib = "lib")
 load("//ts/private:ts_lib.bzl", _lib = "lib")
 
@@ -23,16 +23,7 @@ validate_options = rule(
     attrs = validate_lib.attrs,
 )
 
-ts_project_rule = rule(
-    doc = """Implementation rule behind the ts_project macro.
-    Most users should use [ts_project](#ts_project) instead.
-
-    This skips conveniences like validation of the tsconfig attributes, default settings
-    for srcs and tsconfig, and pre-declaring output files.
-    """,
-    implementation = _ts_project_lib.implementation,
-    attrs = dict(_ts_project_lib.attrs),
-)
+ts_project_rule = _ts_project
 
 def _is_file_missing(label):
     """Check if a file is missing by passing its relative path through a glob().

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -294,7 +294,18 @@ This is an error because Bazel does not run actions unless their outputs are nee
 
     return providers
 
-ts_project = struct(
+lib = struct(
     implementation = _ts_project_impl,
     attrs = dicts.add(COMPILER_OPTION_ATTRS, STD_ATTRS, OUTPUT_ATTRS),
+)
+
+ts_project = rule(
+    doc = """Implementation rule behind the ts_project macro.
+    Most users should use [ts_project](#ts_project) instead.
+
+    This skips conveniences like validation of the tsconfig attributes, default settings
+    for srcs and tsconfig, and pre-declaring output files.
+    """,
+    implementation = lib.implementation,
+    attrs = lib.attrs,
 )


### PR DESCRIPTION
This makes the abstraction less breaking when you bazel query.

Fixes #360

BREAKING CHANGE:
Any bazel query expressions, aspect implementations, or other "leaky abstractions" that keyed on the kind of the underlying rule being "ts_project_rule" will need to be updated to the new name "ts_project".

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

on `main`
```
bazel query --output=label_kind examples/tsconfig_external
ts_project_rule rule //examples/tsconfig_external:tsconfig_external
```

with this change
```
bazel query --output=label_kind examples/tsconfig_external

ts_project rule //examples/tsconfig_external:tsconfig_external
```