### PR TITLE
chore: upgrade to Bazel 7

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.4.0
+7.0.1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,11 +40,13 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - id: bazel_6
+              run: echo "bazelversion=6.2.0" >> $GITHUB_OUTPUT
+            - id: bazel_7
               run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
             - id: bazel_7
               run: echo "bazelversion=7.0.0-pre.20230530.3" >> $GITHUB_OUTPUT
         outputs:
-            # Will look like ["<version from .bazelversion>", "7.0.0-pre.*", "6.3.1"]
+            # Will look like ["6.2.0", "<version from .bazelversion>"]
             bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
     matrix-prep-os:


### PR DESCRIPTION
Continue running tests against LTS (Bazel 6)

Note, we dropped Bazel 5 in https://github.com/aspect-build/rules_ts/pull/372 but didn't document that.

BREAKING CHANGE:
rules_ts 2.0 requires Bazel 6.0 or greater.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
