### PR TITLE
fix: add missing ts_version_from to bzlmod API

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,3 +10,10 @@ bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "1.23.1")
 bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+
+rules_ts_ext = use_extension(
+    "@aspect_rules_ts//ts:extensions.bzl",
+    "ext",
+    dev_dependency = True,
+)
+rules_ts_ext.deps(ts_version_from = "//examples:package.json")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -20,6 +20,9 @@ rules_ts_ext = use_extension(
     dev_dependency = True,
 )
 
-rules_ts_ext.deps()
+rules_ts_ext.deps(
+    # This keeps the TypeScript version in-sync with the editor, which is typically best.
+    ts_version_from = "//:package.json",
+)
 
 use_repo(rules_ts_ext, "npm_typescript")

--- a/e2e/bzlmod/package.json
+++ b/e2e/bzlmod/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "typescript": "4.8.4"
+    }
+}

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -8,11 +8,18 @@ load("//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION")
 def _extension_impl(module_ctx):
     for mod in module_ctx.modules:
         for attr in mod.tags.deps:
-            npm_dependencies(ts_version = attr.ts_version, ts_integrity = attr.ts_integrity)
+            ts_version = attr.ts_version
+            if not ts_version and not attr.ts_version_from:
+                ts_version = LATEST_TYPESCRIPT_VERSION
+            npm_dependencies(ts_version = ts_version, ts_version_from = attr.ts_version_from, ts_integrity = attr.ts_integrity)
 
 ext = module_extension(
     implementation = _extension_impl,
     tag_classes = {
-        "deps": tag_class(attrs = {"ts_version": attr.string(default = LATEST_TYPESCRIPT_VERSION), "ts_integrity": attr.string()}),
+        "deps": tag_class(attrs = {
+            "ts_version": attr.string(),
+            "ts_version_from": attr.label(),
+            "ts_integrity": attr.string(),
+        }),
     },
 )


### PR DESCRIPTION
Bug in the sense that it should be in the bzlmod API since it is already in the WORKSPACE API.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- New test cases added
