### PR TITLE
feat: update mirrored TS versions

### DIFF
--- a/ts/private/versions.bzl
+++ b/ts/private/versions.bzl
@@ -153,4 +153,5 @@ TOOL_VERSIONS = {
     "5.0.4": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
     "5.1.3": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
     "5.1.5": "sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==",
+    "5.1.6": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
 }


### PR DESCRIPTION
Updates the mirrored TS versions to include 5.1.6.

---

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Suggested release notes are provided below:

Add Typescript versions 5.1.5 and 5.1.6 to the mirrored TS versions.

### Test plan

- Covered by existing test cases