### PR TITLE
chore: bump rules_js dep to 1.29.2 to pickup Windows fix

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,8 +1,7 @@
 bcr_test_module:
     module_path: 'e2e/bzlmod'
     matrix:
-        # TODO(aspect-team): windows https://github.com/aspect-build/rules_ts/issues/228
-        platform: ['debian10', 'macos', 'ubuntu2004']
+        platform: ['debian10', 'macos', 'ubuntu2004', 'windows']
     tasks:
         run_tests:
             name: 'Run test module'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
 bazel_dep(name = "rules_nodejs", version = "5.8.2", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "1.23.1")
+bazel_dep(name = "aspect_rules_js", version = "1.29.2")
 bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
 
 rules_ts_ext = use_extension(

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 # repeated here only because we use the platforms definitions for rbe
-bazel_dep(name = "aspect_rules_js", version = "1.23.1", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "1.29.2", dev_dependency = True)
 bazel_dep(name = "aspect_rules_ts", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
 

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -51,9 +51,9 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "2a1e5d4400e2b49f6d36785aa894412670a0babfe7054e733b6a8f23c1b41e26",
-        strip_prefix = "rules_js-1.23.1",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.23.1/rules_js-v1.23.1.tar.gz",
+        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
+        strip_prefix = "rules_js-1.29.2",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Windows fix. BCR should be green now for Windows with this change.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
