### PR TITLE
Make `is_typescript_5_or_greater` config_setting public

### DIFF
--- a/ts/BUILD.typescript
+++ b/ts/BUILD.typescript
@@ -19,6 +19,7 @@ config_setting(
     flag_values = {
         ":is_typescript_5_or_greater_flag": "true",
     },
+    visibility = ["//visibility:public"],
 )
 
 npm_package_internal(


### PR DESCRIPTION
`is_typescript_5_or_greater` is referenced from `ts_project` macro. Which means that the config_setting is referenced from non-internal user packages and has to be public. Currently bazel has default behavior where config_settings are considered public by default but some projects choose to opt-out of that legacy behavior. In such cases using TS 5+ is impossible at the moment. 

See config_setting visibility: https://bazel.build/concepts/visibility#config-setting-visibility 

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Suggested release notes are provided below: 
Fixes build errors for TS 5+ users who enale `--incompatible_config_setting_private_default_visibility` bazel flag.

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Build ts_project target with TS 5+ using: `
build --incompatible_config_setting_private_default_visibility  --incompatible_enforce_config_setting_visibility //path/to:target`