### PR TITLE
Revert "Make `is_typescript_5_or_greater` config_setting public"

### DIFF
--- a/ts/BUILD.typescript
+++ b/ts/BUILD.typescript
@@ -19,7 +19,6 @@ config_setting(
     flag_values = {
         ":is_typescript_5_or_greater_flag": "true",
     },
-    visibility = ["//visibility:public"],
 )
 
 npm_package_internal(


### PR DESCRIPTION
Reverts aspect-build/rules_ts#389

CLA needs to be signed before merge.