### PR TITLE
chore(2.0): remove VERBOSE_LOGS env var

### DIFF
--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -80,12 +80,6 @@ config_setting(
     flag_values = {":skipLibCheck": "honor_tsconfig"},
 )
 
-# TODO(2.0): remove this
-config_setting(
-    name = "legacy_verbose",
-    define_values = {"VERBOSE_LOGS": "1"},
-)
-
 config_setting(
     name = "verbose_flag",
     flag_values = {
@@ -126,7 +120,6 @@ options(
         "//conditions:default": False,
     }),
     verbose = select({
-        ":legacy_verbose": True,
         ":verbose_flag": True,
         "//conditions:default": False,
     }),

--- a/ts/private/options.bzl
+++ b/ts/private/options.bzl
@@ -57,11 +57,6 @@ OptionsInfo = provider(
 def _options_impl(ctx):
     verbose = ctx.attr.verbose
 
-    # TODO(2.0): remove this
-    if "VERBOSE_LOGS" in ctx.var.keys():
-        # buildifier: disable=print
-        print("Usage of --define=VERBOSE_LOGS=1 is deprecated. use --@aspect_rules_ts//ts:verbose=true flag instead.")
-
     args = []
 
     # When users report problems, we can ask them to re-build with


### PR DESCRIPTION
### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)
- Suggested release notes are provided below:

`--define=VERBOSE_LOGS` no longer has an effect, use the `--@aspect_rules_ts//ts:verbose=true` flag instead

### Test plan

- Covered by existing test cases
