### PR TITLE
chore(docs): move transpiler migration instructions to markdown

### DIFF
--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -1,15 +1,13 @@
 # Transpiling TypeScript to JavaScript
 
 The TypeScript compiler `tsc` can perform type-checking, transpilation to JavaScript, or both.
-Type-checking can be slow, and is really only possible with TypeScript, not with alternative tools, because the type system is so rich that writing a correct checker is a massive undertaking.
-
+Type-checking is typically slow, and is really only possible with TypeScript, not with alternative tools.
 Transpilation is mostly "erase the type syntax" and can be done well by a variety of tools.
-`tsc` is regarded as the slowest option for transpilation, so it makes sense to divide the work between two tools. 
 
-`ts_project` supports this with the following design goals:
+`ts_project` allows us to split the work, with the following design goals:
 
-- The user should only need a single BUILD.bazel declaration of "this is my TypeScript code and its dependencies".
-- Most developers have a working TypeScript Language Service in their editor, so they got type hinting before they ran the build tool.
+- The user should only need a single BUILD.bazel declaration: "these are my TypeScript sources and their dependencies".
+- Most developers have a working TypeScript Language Service in their editor, so they got type hinting before they ran `bazel`.
 - Development activities which rely only on runtime code, like running tests or manually verifying behavior in a devserver, should not need to wait on type-checking.
 - Type-checking still needs to be verified before checking in the code, but only needs to be as fast as a typical test.
 
@@ -17,26 +15,82 @@ Read more: https://blog.aspect.dev/typescript-speedup
 
 ## ts_project#transpiler
 
-The `transpiler` attribute of `ts_project` lets you select which tool produces the JavaScript outputs. The default value of `None` means that `tsc` should do transpiling along with type-checking, as this is the simplest configuration without additional dependencies. However as noted above, it's also the slowest.
+The `transpiler` attribute of `ts_project` lets you select which tool produces the JavaScript outputs.
 
-The `transpiler` attribute accepts a rule or macro with this signature:
-`name, srcs, **kwargs`
-where the `**kwargs` attribute propagates the tags, visibility, and testonly attributes from `ts_project`.
+### [SWC](http://swc.rs) (recommended)
 
-If you need to pass additional attributes to the transpiler rule such as `out_dir`, you can use a
-[partial](https://github.com/bazelbuild/bazel-skylib/blob/main/lib/partial.bzl)
-to bind those arguments at the "make site", then pass that partial to this attribute where it will be called with the remaining arguments.
-The transpiler rule or macro is responsible for predicting and declaring outputs.
-If you want to pre-declare the outputs (so that they can be addressed by a Bazel label, like `//path/to:index.js`)
-then you should use a macro which calculates the predicted outputs and supplies them to a `ctx.attr.outputs` attribute
-on the rule.
+SWC is a fast transpiler, and the authors of rules_ts recommend using it.
+This option results in the fastest development round-trip time, however it may have subtle
+compatibility issues: https://github.com/aspect-build/rules_ts/discussions/398
+
+To switch to SWC, follow these steps:
+
+1. Install a [recent release of rules_swc](https://github.com/aspect-build/rules_swc/releases)
+2. Load `swc`. You can automate this by running:
+
+    npx @bazel/buildozer 'fix movePackageToTop' //...:__pkg__
+    npx @bazel/buildozer 'new_load @aspect_rules_swc//swc:defs.bzl swc' //...:__pkg__
+
+3. In the simplest case you can skip passing attributes to swc (such as an `.swcrc` file).
+   You can update your `ts_project` rules with this command:
+
+    npx @bazel/buildozer 'set transpiler swc' //...:%ts_project
+
+4. However, most codebases do rely on configuration options for swc.
+
+  a. [Synchronize settings with tsconfig.json](https://github.com/aspect-build/rules_swc/blob/main/docs/tsconfig.md)
+  b. To pass arguments, use a pattern like the following:
+
+    load("@aspect_rules_swc//swc:defs.bzl", "swc")
+    load("@bazel_skylib//lib:partial.bzl", "partial")
+
+    ts_project(
+        ...
+        transpiler = partial.make(swc, swcrc = "//:.swcrc"),
+    )
+
+5. Cleanup unused load statements:
+
+    npx @bazel/buildozer 'fix unusedLoads' //...:__pkg__
+
+### [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html):
+
+The default `transpiler` value of `None` means that `tsc` should do transpiling along with type-checking.
+This is the simplest configuration without additional dependencies. However, it's also the slowest.
+
+> Note that rules_ts used to recommend a "Persistent Worker" mode to keep the `tsc` process running
+> as a background daemon, however this introduces correctness issues in the build and is no longer
+> recommended. As of rules_ts 2.0, the "Persistent Worker" mode is no longer enabled by default.
+
+To choose this option, simply add this to /.bazelrc:
+
+    # Use "tsc" as the transpiler when ts_project has no `transpiler` set.
+    build --@aspect_rules_ts//ts:default_to_tsc_transpiler
+
+### Other Transpilers
+
+The `transpiler` attribute accepts any rule or macro with this signature: `(name, srcs, **kwargs)`
+The `**kwargs` attribute propagates the tags, visibility, and testonly attributes from `ts_project`.
+
 See the examples/transpiler directory for a simple example using Babel, or
 <https://github.com/aspect-build/bazel-examples/tree/main/ts_project_transpiler>
 for a more complete example that also shows usage of SWC.
 
+If you need to pass additional attributes to the transpiler rule such as `out_dir`, you can use a
+[partial](https://github.com/bazelbuild/bazel-skylib/blob/main/lib/partial.bzl)
+to bind those arguments at the "make site", then pass that partial to this attribute where it will be called with the remaining arguments.
+
+The transpiler rule or macro is responsible for predicting and declaring outputs.
+If you want to pre-declare the outputs (so that they can be addressed by a Bazel label, like `//path/to:index.js`)
+then you should use a macro which calculates the predicted outputs and supplies them to a `ctx.attr.outputs` attribute
+on the rule.
+
+You may want to create a `ts_project` macro within your repository where your choice is setup,
+then `load()` from your own macro rather than from `@aspect_rules_ts`.
+
 ## Macro expansion
 
-When a custom transpiler is used, then the `ts_project` macro expands to these targets:
+When `transpiler` is used, then the `ts_project` macro expands to these targets:
 
 - `[name]` - the default target which can be included in the `deps` of downstream rules.
     Note that it will successfully build *even if there are typecheck failures* because invoking `tsc` is not needed to produce the default outputs.
@@ -52,3 +106,27 @@ When a custom transpiler is used, then the `ts_project` macro expands to these t
 
 [`build_test`]: https://github.com/bazelbuild/bazel-skylib/blob/main/rules/build_test.bzl
 [`--build_tests_only`]: https://docs.bazel.build/versions/main/user-manual.html#flag--build_tests_only
+
+## Avoid eager type-checks via `npm_package`
+
+A common pattern to link monorepo packages is to use the [`npm_package`](https://docs.aspect.build/rules/aspect_rules_js/docs/npm_package) rule.
+
+When typings files (`*.d.ts`) are included in the `npm_package`, this can cause the type-checker to run, even for a development round-trip that shouldn't need it.
+
+For example,
+
+```
+ts_project(name = a) --foo.d.ts--> npm_package ---> npm_link_package ---> ts_project(name = b) ---> js_test
+```
+
+In this diagram, we'd like to be able to change the TypeScript sources of `a` and then re-run the test target, without waiting for type-checking.
+However, since `foo.d.ts` is declared as an input to the `npm_package` rule, Bazel needs to produce it.
+
+To solve this, you can add the flag `--@aspect_rules_js//npm:exclude_declarations_from_npm_packages` to your `bazel` command.
+
+Use this flag only for local development! You can add a line to your `.bazelrc` to make this easier to type, for example:
+
+```
+# Run bazel --config=dev to choose these options:
+build:dev --@aspect_rules_js//npm:exclude_declarations_from_npm_packages
+```

--- a/ts/private/options.bzl
+++ b/ts/private/options.bzl
@@ -5,46 +5,8 @@ transpiler_selection_required = """\
 ######## Required Transpiler Selection ########
 
 You must select a transpiler for ts_project rules, which produces the .js outputs.
-For more information, see https://docs.aspect.build/rules/aspect_rules_ts/docs/transpiler
 
-1. Use [SWC](https://swc.rs/) for transpiles (recommended)
-
-    This option results in the fastest development round-trip time, however it may have subtle
-    compatibility issues: https://github.com/aspect-build/rules_ts/discussions/398
-
-    Add rules_swc to your Bazel project, following instructions on a recent release:
-    https://github.com/aspect-build/rules_swc/releases
-
-    If you don't need any .swcrc, you can run these commands to fixup your `ts_project` calls:
-
-        npx @bazel/buildozer 'fix movePackageToTop' //...:__pkg__
-        npx @bazel/buildozer 'new_load @aspect_rules_swc//swc:defs.bzl swc' //...:__pkg__
-        npx @bazel/buildozer 'set transpiler swc' //...:%ts_project
-        npx @bazel/buildozer 'fix unusedLoads' //...:__pkg__
-    
-    To use an .swcrc file, see option 3 below.
-
-2. Use [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html):
-
-    In rules_ts 1.x, the default value is to have TypeScript do both type-checking and transpilation.
-    However, this is the slowest choice, and we no longer recommend this.
-
-    Note that rules_ts used to recommend a "Persistent Worker" mode to keep the `tsc` process running
-    as a background daemon, however this introduces correctness issues in the build and is no longer
-    recommended.
-
-    Add this to /.bazelrc:
-
-        # Use "tsc" as the transpiler when ts_project has no `transpiler` set.
-        build --@aspect_rules_ts//ts:default_to_tsc_transpiler
-
-3. Use a custom transpiler
-
-    You can set the `transpiler` attribute of each `ts_project` to any rule or macro.
-    This could be swc with some custom arguments, babel, esbuild, or any other tool.
-
-    You may want to create a `ts_project` macro within your repository where your choice is setup,
-    then load() from your own macro rather than from @aspect_rules_ts.
+Please read https://docs.aspect.build/rules/aspect_rules_ts/docs/transpiler
 
 ##########################################################
 """


### PR DESCRIPTION
This includes a section about the new flag in rules_js to avoid npm_package causing type-checks.

---

### Type of change

- Documentation (updates to documentation or READMEs)

### Test plan

None