### PR TITLE
chore: remove maybe helper

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -10,6 +10,7 @@ stardoc_with_diff_test(
 stardoc_with_diff_test(
     name = "repositories",
     bzl_library_target = "//ts:repositories",
+    symbol_names = ["rules_ts_dependencies"],
 )
 
 update_docs(name = "update")

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -4,8 +4,11 @@ Users should *not* need to install these. If users see a load()
 statement from these, that's a bug in our distribution.
 """
 
-# buildifier: disable=bzl-visibility
-load("//ts/private:maybe.bzl", http_archive = "maybe_http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
 def rules_ts_internal_deps():
     "Fetch deps needed for local development"

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -157,7 +157,6 @@ bzl_library(
     srcs = ["repositories.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "//ts/private:maybe",
         "//ts/private:npm_repositories",
         "//ts/private:versions",
         "@bazel_tools//tools/build_defs/repo:http.bzl",

--- a/ts/private/BUILD.bazel
+++ b/ts/private/BUILD.bazel
@@ -8,16 +8,6 @@ exports_files(
 )
 
 bzl_library(
-    name = "maybe",
-    srcs = ["maybe.bzl"],
-    visibility = ["//ts:__subpackages__"],
-    deps = [
-        "@bazel_tools//tools/build_defs/repo:http.bzl",
-        "@bazel_tools//tools/build_defs/repo:utils.bzl",
-    ],
-)
-
-bzl_library(
     name = "npm_repositories",
     srcs = ["npm_repositories.bzl"],
     visibility = ["//ts:__subpackages__"],

--- a/ts/private/maybe.bzl
+++ b/ts/private/maybe.bzl
@@ -1,7 +1,0 @@
-"maybe utilities"
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-
-def maybe_http_archive(**kwargs):
-    maybe(_http_archive, **kwargs)

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -4,9 +4,13 @@ These are needed for local dev, and users must install them as well.
 See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 """
 
-load("//ts/private:maybe.bzl", http_archive = "maybe_http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//ts/private:npm_repositories.bzl", "npm_dependencies")
 load("//ts/private:versions.bzl", "TOOL_VERSIONS")
+
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
 LATEST_TYPESCRIPT_VERSION = TOOL_VERSIONS.keys()[-1]
 


### PR DESCRIPTION
It is a two-line implementation, so the redirection of an extra starlark file isn't worth it.

Technically non-breaking as it's private API, but doing this on 2.0 anyway.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)
 
### Test plan

- Covered by existing test cases
