### PR TITLE
chore: bump rules_js version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,10 @@ load("//ts:repositories.bzl", "rules_ts_dependencies")
 # bazel run -- @npm_typescript//:tsc --version
 rules_ts_dependencies(ts_version_from = "//examples:package.json")
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
 aspect_bazel_lib_dependencies(override_local_config_platform = True)

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -9,6 +9,10 @@ load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rule
 
 rules_ts_dependencies(ts_version = LATEST_TYPESCRIPT_VERSION)
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/e2e/external_dep/app/WORKSPACE
+++ b/e2e/external_dep/app/WORKSPACE
@@ -12,6 +12,10 @@ load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rule
 
 rules_ts_dependencies(ts_version = LATEST_TYPESCRIPT_VERSION)
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/e2e/test/common.bats
+++ b/e2e/test/common.bats
@@ -24,6 +24,14 @@ load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
 # TODO(#361): upgrade to 5.x
 rules_ts_dependencies(ts_version = "4.9.5")
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/e2e/worker/WORKSPACE
+++ b/e2e/worker/WORKSPACE
@@ -10,6 +10,10 @@ load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
 # TODO(#361): upgrade to 5.x
 rules_ts_dependencies(ts_version = "4.9.5")
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -25,6 +25,14 @@ rules_ts_dependencies(
     # ts_version = LATEST_TYPESCRIPT_VERSION
 )
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 # Fetch and register node, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -52,9 +52,9 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
-        strip_prefix = "rules_js-1.29.2",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
+        sha256 = "bdbd6df52fc7963f55281fe0a140e21de8ec587ab711a8a2fff0715b6710a4f8",
+        strip_prefix = "rules_js-1.32.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.32.0/rules_js-v1.32.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
This requires calling rules_js_dependencies when called in WORKSPACE, which we had previously skipped. We also need to call the bazel_features_deps in cases that the bazel_features_globals repo gets referenced.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

Technically this is breaking if you rely on rules_ts to provide your rules_js version, now you may need to setup bazel_features as well.

### Test plan

- Covered by existing test cases
