### PR TITLE
chore: disable bzlmod on Aspect Workflows

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,8 +1,5 @@
 # See https://docs.aspect.build/v/workflows/config
 ---
-bazel:
-    flags:
-        - --enable_bzlmod
 tasks:
     buildifier:
     test:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,10 +7,11 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "5.8.2", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "1.29.2")
 bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
+
+bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "5.8.2", dev_dependency = True)
 
 rules_ts_ext = use_extension(
     "@aspect_rules_ts//ts:extensions.bzl",


### PR DESCRIPTION
bzlmod doesn't work fully yet in the root repository. https://github.com/aspect-build/rules_ts/pull/424 is a start to fix it up but it is not yet finished.

this should fix the warming job at HEAD which is currently [red](https://github.com/aspect-build/rules_ts/actions/workflows/aspect-workflows-warming.yaml)