### PR TITLE
fix: don't recommend bazelrc common verb

### DIFF
--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -78,10 +78,6 @@ You can simply disable this error for all targets in the build, behaving the sam
 Just add this to `/.bazelrc``:
 
     # Use "tsc" as the transpiler when ts_project has no `transpiler` set.
-    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
-    common --@aspect_rules_ts//ts:default_to_tsc_transpiler
-
-    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:default_to_tsc_transpiler
     fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
     query --@aspect_rules_ts//ts:default_to_tsc_transpiler

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -28,10 +28,6 @@ You must choose exactly one of the following flags:
 1. To choose the faster performance put this in /.bazelrc:
 
     # passes an argument `--skipLibCheck` to *every* spawn of tsc
-    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
-    common --@aspect_rules_ts//ts:skipLibCheck=always
-
-    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:skipLibCheck=always
     fetch --@aspect_rules_ts//ts:skipLibCheck=always
     query --@aspect_rules_ts//ts:skipLibCheck=always
@@ -39,10 +35,6 @@ You must choose exactly one of the following flags:
 2. To choose more correct typechecks, put this in /.bazelrc:
 
     # honor the setting of `skipLibCheck` in the tsconfig.json file
-    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
-    common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-
-    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
     fetch --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
     query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig


### PR DESCRIPTION
It doesn't work with custom flags even in Bazel 6.3

Thanks @fmeum for confirming.
