### PR TITLE
fix: add missing data dep

### DIFF
--- a/examples/connect_node/BUILD.bazel
+++ b/examples/connect_node/BUILD.bazel
@@ -30,6 +30,7 @@ js_binary(
     data = [
         ":connect_node",
         ":node_modules/@bufbuild/protobuf",
+        ":package.json",
     ],
     entry_point = "server.js",
 )


### PR DESCRIPTION
This was non-hermetic, it passed on my machine due to files copied into bazel-out, but then after a bazel clean I could reproduce #434

Fixes #434 