### PR TITLE
feat: stamp our version into release

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,6 +9,14 @@ TAG=${GITHUB_REF_NAME}
 PREFIX="rules_ts-${TAG:1}"
 ARCHIVE="rules_ts-$TAG.tar.gz"
 
+# Don't include examples in the distribution artifact, to reduce size
+# Note, we do need to include e2e/bzlmod since BCR runs our test based on distribution artifact.
+# Also stamp the release version into the repo
+cat >.git/info/attributes <<EOF
+examples                 export-ignore
+ts/private/versions.bzl  export-subst
+EOF
+
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 

--- a/ts/private/versions.bzl
+++ b/ts/private/versions.bzl
@@ -4,6 +4,10 @@ Update with:
 curl --silent https://registry.npmjs.org/typescript | jq '[.versions[] | select(.version | test("^[0-9.]+$")) | {key: .version, value: .dist.integrity}] | from_entries'
 """
 
+# Replaced during publishing, see .github/workflows/release_prep.sh
+# Note: this requires a newer git version, 2.25.1 is too old, but GHA runs with 2.41.0 as of Sep 2023
+RULES_TS_VERSION = "$Format:%(describe:tags=true)$"
+
 # Versions should be ascending order so TOOL_VERSIONS.keys()[-1] is the latest version.
 TOOL_VERSIONS = {
     "0.8.0": "sha512-t4DYxzL6Gt3+TRuJXtmh+3KfcY5iSM8J4lzUgfQkTOr78xFbmor79x/dQEGMaiqO2HJBbFGO3RlIaxPzpP5JMA==",


### PR DESCRIPTION
We can use this at runtime to support features like checking for updates.