### PR TITLE
fix: ensure ts_project does not propagate testonly to build_test

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -383,7 +383,8 @@ def ts_project(
         build_test(
             name = test_target_name,
             targets = [typecheck_target_name],
-            **common_kwargs
+            tags = common_kwargs.get("tags"),
+            visibility = common_kwargs.get("visibility"),
         )
 
         # Default target produced by the macro gives the js and map outs, with the transitive dependencies.


### PR DESCRIPTION
Skylib build_test is a test rule with testonly dependencies. ts_project accepts kwargs and passes common ones through when expanding. The testonly attribute is no longer passed to build_test to prevent analysis errors.

---

https://github.com/aspect-build/rules_ts/issues/468

### Type of change

This is a minor bugfix to remove testonly when specifying kwargs on build_test as called by ts_project. 

**For changes visible to end-users**

Technically, this is visible to end-users but only expands functionality and allows target configurations that previously wouldn't build to now build.

### Test plan

This has been manually tested in the repo by modifying `//ts/test:transpile_filegroup` to take `testonly = False`, which breaks the build by causing `//ts/test:transpile_filegroup_typecheck_test` to fail during analysis.

It is possible to leave such a test in to cover future regressions, but this edge case is uncommon and probably not worth what is otherwise clutter in the test code.
