### PR TITLE
chore: update buildifier targets used by Aspect Workflows

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,10 +13,15 @@ gazelle(
 )
 
 buildifier(
+    name = "buildifier",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier(
     name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-    ],
+    exclude_patterns = ["./.git/*"],
     lint_mode = "warn",
     mode = "diff",
 )


### PR DESCRIPTION
Aspect Workflows currently expects a `//:buildifier.check` target for checking and a `//:buildifier` target that is the suggested target to run when the buildifier check is red