### PR TITLE
examples: reproduce swc paths resolving to sandbox

### DIFF
--- a/examples/grandparent/BUILD.bazel
+++ b/examples/grandparent/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@npm//examples:tsconfig-to-swcconfig/package_json.bzl", tsconfig_to_swcconfig = "bin")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = [":__subpackages__"],
+)
+
+tsconfig_to_swcconfig.t2s(
+    name = "write_swcrc",
+    srcs = ["tsconfig.json"],
+    args = [
+        "--filename",
+        "$(location tsconfig.json)",
+    ],
+    stdout = ".swcrc",
+    visibility = [":__subpackages__"],
+)
+
+ts_project(
+    name = "grandparent",
+    srcs = ["index.ts"],
+    declaration = True,
+    transpiler = partial.make(
+        swc,
+        swcrc = ":.swcrc",
+    ),
+    tsconfig = ":tsconfig",
+    deps = ["//examples/grandparent/parent"],
+)

--- a/examples/grandparent/index.ts
+++ b/examples/grandparent/index.ts
@@ -1,0 +1,3 @@
+import { parentName } from '@myorg/grandparent/parent'
+
+export const grandparentName = parentName + "'s grandparent"

--- a/examples/grandparent/parent/BUILD.bazel
+++ b/examples/grandparent/parent/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+
+ts_project(
+    name = "parent",
+    srcs = ["index.ts"],
+    declaration = True,
+    transpiler = partial.make(
+        swc,
+        swcrc = "//examples/grandparent:.swcrc",
+    ),
+    tsconfig = "//examples/grandparent:tsconfig",
+    visibility = ["//visibility:public"],
+    deps = ["//examples/grandparent/parent/child"],
+)

--- a/examples/grandparent/parent/child/BUILD.bazel
+++ b/examples/grandparent/parent/child/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+
+ts_project(
+    name = "child",
+    srcs = ["index.ts"],
+    declaration = True,
+    transpiler = partial.make(
+        swc,
+        swcrc = "//examples/grandparent:.swcrc",
+    ),
+    tsconfig = "//examples/grandparent:tsconfig",
+    visibility = ["//visibility:public"],
+)

--- a/examples/grandparent/parent/child/index.ts
+++ b/examples/grandparent/parent/child/index.ts
@@ -1,0 +1,1 @@
+export const name = 'Jack'

--- a/examples/grandparent/parent/index.ts
+++ b/examples/grandparent/parent/index.ts
@@ -1,0 +1,3 @@
+import { name } from '@myorg/grandparent/parent/child'
+
+export const parentName = name + "'s parent"

--- a/examples/grandparent/tsconfig.json
+++ b/examples/grandparent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "declaration": true,
+        "baseUrl": ".",
+        // Path Mapping the examples folder as '@myorg/*'.
+        "paths": {
+            "@myorg/*": ["../*"]
+        }
+    }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -17,6 +17,7 @@
         "jasmine": "4.6.0",
         "rxjs": "7.5.7",
         "source-map-support": "^0.5.21",
+        "tsconfig-to-swcconfig": "^2.7.0",
         "typescript": "4.8.4",
         "zone.js": "0.12.0"
     }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -56,6 +56,9 @@ importers:
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
+      tsconfig-to-swcconfig:
+        specifier: ^2.7.0
+        version: 2.7.0
       typescript:
         specifier: 4.8.4
         version: 4.8.4
@@ -1159,6 +1162,12 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: false
 
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: false
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1459,6 +1468,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: false
+
   /ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
@@ -1603,6 +1616,14 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: false
+
+  /tsconfig-to-swcconfig@2.7.0:
+    resolution: {integrity: sha512-S6O8ZOawd1yw/Vau98TPIaqHs3N22PRZImFDDnc776XPpuZ9iGNPo1ggO1ARLuL0BcpY7zipXl93RJXjEzcDbw==}
+    hasBin: true
+    dependencies:
+      '@fastify/deepmerge': 1.3.0
+      get-tsconfig: 4.7.2
     dev: false
 
   /tslib@2.6.2:


### PR DESCRIPTION
### Type of change

- Issue reproduction

### Motivation

- Minimal reproduction of sandbox paths being present in transpiled javascript after swc transpilation of `.ts` imports using tsconfig paths.

### Context

I am bundling javascript modules that are transpiled using swc. The bundler cannot resolve the paths transpiled via swc when tsconfig paths are configured since the transpiled paths contain sandbox paths. 

Prior to switching to swc, tsc ignores these imports (treating them as pure javascript) and so there is no issue. With swc, these paths are resolved to their relative paths during transpilation. This works for relative paths that are alongside the tsconfig, but not when those relative paths are nested from the tsconfig.

### Reproduction steps

1. `bazel build //examples/grandparent`.
2. review `bazel-bin/examples/grandparent/index.js` (resolved path is relative to .ts file).

```
import { parentName } from "./parent/index";
export const grandparentName = parentName + "'s grandparent";
```

3. review `bazel-bin/examples/grandparent/parent/index.js` (resolved path is relative to sandbox).

```
import { name } from "../../../../../../../../private/var/tmp/_bazel_jack.vincent/5f33d7eefddc1bdc8bb8bb38dea57fd4/sandbox/darwin-sandbox/797/execroot/grandparent/parent/child";
export const parentName = name + "'s parent";
```

The only difference between the parent and the grandparent is the distance from the `tsconfig` in the directory tree. The grandparent is in the same directory, and the parent is in a nested directory.
