### PR TITLE
refactor: suggest naming node toolchain 'nodejs'

### DIFF
--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -37,7 +37,7 @@ bazel_features_deps()
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
-    name = "node",
+    name = "nodejs",
     node_version = DEFAULT_NODE_VERSION,
 )
 


### PR DESCRIPTION
Per #474 this helps to avoid some conflict with some other code which assumes that name.

Fixes #474
