### PR TITLE
chore: enable lib checks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,6 @@
 # import common bazelrc settings used in this repository and in nested workspaces
 import %workspace%/.bazelrc.common
 
-# passes an argument `--skipLibCheck` to *every* spawn of tsc
-build --@aspect_rules_ts//ts:skipLibCheck=always
-
 # Disable lockfile for now. It is unstable.
 # https://github.com/bazelbuild/bazel/issues/19026
 # https://github.com/bazelbuild/bazel/issues/19621

--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -70,13 +70,9 @@ build:macos --nolegacy_external_runfiles
 build:freebsd --nolegacy_external_runfiles
 build:openbsd --nolegacy_external_runfiles
 
-# TODO: switch to 'common' once https://github.com/bazelbuild/bazel/pull/19363 is landed and available in Bazel
-build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-fetch --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-build --@aspect_rules_ts//ts:default_to_tsc_transpiler
-fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
-query --@aspect_rules_ts//ts:default_to_tsc_transpiler
+# Note: 'common' for custom flags requires Bazel 6.4.0 or greater
+common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
 # Turn on --incompatible_strict_action_env which was on by default
 # in Bazel 0.21.0 but turned off again in 0.22.0. Follow

--- a/examples/connect_node/tsconfig.json
+++ b/examples/connect_node/tsconfig.json
@@ -2,6 +2,8 @@
     "compilerOptions": {
         "lib": ["ES2015"],
         "moduleResolution": "node",
-        "module": "ES2020"
+        "module": "ES2020",
+        // TODO: enable lib check here: repair broken type-check
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
The 'skipLibCheck=always' was added in https://github.com/aspect-build/rules_ts/pull/371 without any explanation of why we'd want that setting for rules_ts itself. This is a prefactor for the regression test of #516 - and in general we should be testing with the 'stricter' setting to make more assurance that the rules behave correctly.

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)

### Test plan

- Covered by existing test cases
