### PR TITLE
Revert "fix: don't recommend bazelrc common verb"

### DIFF
--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -78,13 +78,15 @@ You can simply disable this error for all targets in the build, behaving the sam
 Just add this to `/.bazelrc``:
 
     # Use "tsc" as the transpiler when ts_project has no `transpiler` set.
-    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
+    # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
-    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
+    # Bazel between 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:default_to_tsc_transpiler
     fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
     query --@aspect_rules_ts//ts:default_to_tsc_transpiler
+
+    # ... but prior to Bazel 6.0 only the 'build' and 'fetch' lines.
 
 ### Other Transpilers
 

--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -78,6 +78,10 @@ You can simply disable this error for all targets in the build, behaving the sam
 Just add this to `/.bazelrc``:
 
     # Use "tsc" as the transpiler when ts_project has no `transpiler` set.
+    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
+    common --@aspect_rules_ts//ts:default_to_tsc_transpiler
+
+    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:default_to_tsc_transpiler
     fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
     query --@aspect_rules_ts//ts:default_to_tsc_transpiler

--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -81,12 +81,12 @@ Just add this to `/.bazelrc``:
     # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
-    # Bazel between 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
+    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:default_to_tsc_transpiler
     fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
     query --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
-    # ... but prior to Bazel 6.0 only the 'build' and 'fetch' lines.
+    # Before Bazel 6.0, only the 'build' and 'fetch' lines work.
 
 ### Other Transpilers
 

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -28,6 +28,10 @@ You must choose exactly one of the following flags:
 1. To choose the faster performance put this in /.bazelrc:
 
     # passes an argument `--skipLibCheck` to *every* spawn of tsc
+    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
+    common --@aspect_rules_ts//ts:skipLibCheck=always
+
+    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:skipLibCheck=always
     fetch --@aspect_rules_ts//ts:skipLibCheck=always
     query --@aspect_rules_ts//ts:skipLibCheck=always
@@ -35,6 +39,10 @@ You must choose exactly one of the following flags:
 2. To choose more correct typechecks, put this in /.bazelrc:
 
     # honor the setting of `skipLibCheck` in the tsconfig.json file
+    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
+    common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+
+    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
     fetch --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
     query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -28,25 +28,28 @@ You must choose exactly one of the following flags:
 1. To choose the faster performance put this in /.bazelrc:
 
     # passes an argument `--skipLibCheck` to *every* spawn of tsc
-    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
+    # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:skipLibCheck=always
 
-    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
+    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:skipLibCheck=always
     fetch --@aspect_rules_ts//ts:skipLibCheck=always
     query --@aspect_rules_ts//ts:skipLibCheck=always
 
+    # Before Bazel 6.0, only the 'build' and 'fetch' lines work.
+
 2. To choose more correct typechecks, put this in /.bazelrc:
 
     # honor the setting of `skipLibCheck` in the tsconfig.json file
-    # Bazel 6.3 or greater: 'common' means 'any command that supports this flag'
+    # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 
-    # Prior to Bazel 6.3, you need all of this, to avoid discarding the analysis cache:
+    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
     build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
     fetch --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
     query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 
+    # Before Bazel 6.0, only the 'build' and 'fetch' lines work.
 
 ##########################################################
 """


### PR DESCRIPTION
Reverts aspect-build/rules_ts#431
Bazel 6.4 included @fmeum fix for 'common'.

Fixes #524 