### PR TITLE
chore: re-enable RBE testing

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -37,4 +37,4 @@ build:rbe --remote_executor=grpcs://remote.buildbuddy.io
 # We are using RBE to test that the actions we create in rules_ts will work for our customers,
 # not to accelerate and parallelize the builds for unrelated actions that happen to appear in our dependencies.
 # So, turn off RBE for actions that are known to be problematic because they are non-hermetic.
-build:rbe --modify_execution_info=CppCompile=+no-remote-exec,CppLink=+no-remote-exec,GenProtoDescriptorSet=+no-remote-exec
+build:rbe --modify_execution_info=CppCompile=+no-remote-exec,CppLink=+no-remote-exec,GenProtoDescriptorSet=+no-remote-exec,ProtocGenEs=+no-remote-exec

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -33,3 +33,8 @@ build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --bes_backend=grpcs://remote.buildbuddy.io
 build:rbe --remote_timeout=3600
 build:rbe --remote_executor=grpcs://remote.buildbuddy.io
+
+# We are using RBE to test that the actions we create in rules_ts will work for our customers,
+# not to accelerate and parallelize the builds for unrelated actions that happen to appear in our dependencies.
+# So, turn off RBE for actions that are known to be problematic because they are non-hermetic.
+build:rbe --modify_execution_info=CppCompile=+no-remote-exec,CppLink=+no-remote-exec,GenProtoDescriptorSet=+no-remote-exec

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
             - id: rbe
               run: echo "config=rbe" >> $GITHUB_OUTPUT
               # Don't run RBE if there is no API token which is the case on forks
-              if: false # ${{ env.BUILDBUDDY_API_KEY != '' }}
+              if: ${{ env.BUILDBUDDY_API_KEY != '' }}
         outputs:
             # Will look like ["local", "rbe"]
             configs: ${{ toJSON(steps.*.outputs.config) }}

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -4,6 +4,15 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
+
+# TODO: rules_js shouldn't be required in this module, as we don't reference it anywhere.
+# However, on RBE only (!) we get an error:
+# ERROR: /home/runner/work/rules_ts/rules_ts/e2e/external_dep/app/BUILD:4:11:
+# While resolving toolchains for target //:test: com.google.devtools.build.lib.packages.BuildFileNotFoundException:
+# no such package '@[unknown repo 'aspect_rules_js' requested from @]//platforms':
+# The repository '@[unknown repo 'aspect_rules_js' requested from @]' could not be resolved:
+# No repository visible as '@aspect_rules_js' from main repository
+bazel_dep(name = "aspect_rules_js", version = "1.37.1")
 bazel_dep(name = "aspect_rules_ts", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_ts",

--- a/e2e/external_dep/app/MODULE.bazel
+++ b/e2e/external_dep/app/MODULE.bazel
@@ -4,6 +4,9 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
+
+# TODO: see note on rules_js in the parent MODULE.bazel
+bazel_dep(name = "aspect_rules_js", version = "1.37.1")
 bazel_dep(name = "aspect_rules_ts", version = "0.0.0")
 local_path_override(
     module_name = "aspect_rules_ts",

--- a/ts/private/ts_proto_library.bzl
+++ b/ts/private/ts_proto_library.bzl
@@ -42,6 +42,7 @@ def _protoc_action(ctx, proto_info, outputs, options = {
         progress_message = "Generating .js/.d.ts from %{label}",
         outputs = outputs,
         inputs = inputs,
+        mnemonic = "ProtocGenEs",
         arguments = [args],
         tools = [ctx.executable.protoc_gen_es] + (
             [ctx.executable.protoc_gen_connect_es] if ctx.attr.has_services else []


### PR DESCRIPTION
Revert #529 with fixes

Suspicious workarounds to avoid protobuf problems: non-hermeticity with protoc->glibc and something in C++ toolchain

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
