### PR TITLE
chore: tear out check_for_updates feature

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -11,7 +11,7 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 ## rules_ts_dependencies
 
 <pre>
-rules_ts_dependencies(<a href="#rules_ts_dependencies-ts_version_from">ts_version_from</a>, <a href="#rules_ts_dependencies-ts_version">ts_version</a>, <a href="#rules_ts_dependencies-ts_integrity">ts_integrity</a>, <a href="#rules_ts_dependencies-check_for_updates">check_for_updates</a>)
+rules_ts_dependencies(<a href="#rules_ts_dependencies-ts_version_from">ts_version_from</a>, <a href="#rules_ts_dependencies-ts_version">ts_version</a>, <a href="#rules_ts_dependencies-ts_integrity">ts_integrity</a>)
 </pre>
 
 Dependencies needed by users of rules_ts.
@@ -27,6 +27,5 @@ To skip fetching the typescript package, call `rules_ts_bazel_dependencies` inst
 | <a id="rules_ts_dependencies-ts_version_from"></a>ts_version_from |  label of a json file which declares a typescript version.<br><br>This may be a <code>package.json</code> file, with "typescript" in the dependencies or devDependencies property, and the version exactly specified.<br><br>With rules_js v1.32.0 or greater, it may also be a <code>resolved.json</code> file produced by <code>npm_translate_lock</code>, such as <code>@npm//path/to/linked:typescript/resolved.json</code><br><br>Exactly one of <code>ts_version</code> or <code>ts_version_from</code> must be set.   |  <code>None</code> |
 | <a id="rules_ts_dependencies-ts_version"></a>ts_version |  version of the TypeScript compiler. Exactly one of <code>ts_version</code> or <code>ts_version_from</code> must be set.   |  <code>None</code> |
 | <a id="rules_ts_dependencies-ts_integrity"></a>ts_integrity |  integrity hash for the npm package. By default, uses values mirrored into rules_ts. For example, to get the integrity of version 4.6.3 you could run <code>curl --silent https://registry.npmjs.org/typescript/4.6.3 | jq -r '.dist.integrity'</code>   |  <code>None</code> |
-| <a id="rules_ts_dependencies-check_for_updates"></a>check_for_updates |  Whether to check for newer releases of rules_ts and notify the user with a log message when an update is available.<br><br>Note, to better understand our users, we also include basic information about the build in the request to the update server. This never includes confidential or personally-identifying information (PII). The values sent are:<br><br>- Currently used version. Helps us understand which older release(s) users are stuck on. - bzlmod (true/false). Helps us roll out this feature which is mandatory by Bazel 9. - Some CI-related environment variables to understand usage:     - BUILDKITE_ORGANIZATION_SLUG     - CIRCLE_PROJECT_USERNAME (this is *not* the username of the logged in user)     - GITHUB_REPOSITORY_OWNER     - BUILDKITE_BUILD_NUMBER     - CIRCLE_BUILD_NUM     - GITHUB_RUN_NUMBER   |  <code>True</code> |
 
 

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -15,7 +15,6 @@ def _extension_impl(module_ctx):
                 ts_version = ts_version,
                 ts_version_from = attr.ts_version_from,
                 ts_integrity = attr.ts_integrity,
-                check_for_updates = attr.check_for_updates,
                 bzlmod = True,
             )
 
@@ -26,7 +25,6 @@ ext = module_extension(
             "ts_version": attr.string(),
             "ts_version_from": attr.label(),
             "ts_integrity": attr.string(),
-            "check_for_updates": attr.bool(default = True),
         }),
     },
 )

--- a/ts/private/npm_repositories.bzl
+++ b/ts/private/npm_repositories.bzl
@@ -1,7 +1,7 @@
 """Runtime dependencies fetched from npm"""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//ts/private:versions.bzl", "RULES_TS_VERSION", "TOOL_VERSIONS")
+load("//ts/private:versions.bzl", "TOOL_VERSIONS")
 
 worker_versions = struct(
     bazel_worker_version = "5.4.2",
@@ -9,17 +9,6 @@ worker_versions = struct(
     google_protobuf_version = "3.20.1",
     google_protobuf_integrity = "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw==",
 )
-
-# Keep this list in sync with user documentation.
-# We must inform users what we gather from their builds.
-_TELEMETRY_VARS = [
-    "BUILDKITE_BUILD_NUMBER",
-    "BUILDKITE_ORGANIZATION_SLUG",
-    "CIRCLE_BUILD_NUM",
-    "CIRCLE_PROJECT_USERNAME",
-    "GITHUB_REPOSITORY_OWNER",
-    "GITHUB_RUN_NUMBER",
-]
 
 def _http_archive_version_impl(rctx):
     integrity = None
@@ -74,54 +63,11 @@ def _http_archive_version_impl(rctx):
         executable = False,
     )
 
-    if rctx.attr.check_for_updates:
-        _check_for_updates(rctx)
-
-def _check_for_updates(rctx):
-    version = RULES_TS_VERSION
-
-    # If the placeholder string wasn't replaced, that means we aren't running from a release artifact.
-    # It might be a SHA from GitHub, or a fork of the repo, etc.
-    # We won't be able to say if an update is available, but we count these uses.
-    if version.startswith("$Format"):
-        version = "v0.0.0"
-
-    vars = ["{}={}".format(v, rctx.os.environ[v]) for v in _TELEMETRY_VARS if v in rctx.os.environ]
-    if rctx.attr.bzlmod:
-        vars.append("bzlmod=true")
-    url = "https://update.aspect.build/aspect_rules_ts/{}?{}".format(
-        version,
-        "&".join(vars),
-    )
-    output_path = str(rctx.path(".output/update_check_result"))
-    command = ["curl", url, "--write-out", "%{http_code}", "--output", output_path]
-
-    # Avoid stalling the users Bazel session
-    command.extend(["--connect-timeout", "1", "--max-time", "1"])
-    result = rctx.execute(command)
-    if result.return_code != 0:
-        # Ignore failures when trying to check for new version
-        return
-    status_code = int(result.stdout.strip())
-
-    # 302 Found redirect status response code indicates that the resource requested has been temporarily moved to the URL given by the Location header.
-    # Don't bother the user with any other status code
-    if status_code != 302:
-        return
-
-    # buildifier: disable=print
-    # TODO: print content of output_path which now has the link to the newer version
-    print("""\
-NOTICE: a newer version of rules_ts is available.
-See https://github.com/aspect-build/rules_ts/releases
-""")
-
 http_archive_version = repository_rule(
     doc = "Re-implementation of http_archive that can read the version from package.json",
     implementation = _http_archive_version_impl,
     attrs = {
         "bzlmod": attr.bool(doc = "Whether we were called from a bzlmod module extension"),
-        "check_for_updates": attr.bool(doc = "Whether to check for a newer version of rules_ts"),
         "integrity": attr.string(doc = "Needed only if the ts version isn't mirrored in `versions.bzl`."),
         "version": attr.string(doc = "Explicit version for `urls` placeholder. If provided, the package.json is not read."),
         "urls": attr.string_list(doc = "URLs to fetch from. Each must have one `{}`-style placeholder."),
@@ -132,7 +78,7 @@ http_archive_version = repository_rule(
 )
 
 # buildifier: disable=function-docstring
-def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None, bzlmod = False, check_for_updates = True):
+def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None, bzlmod = False):
     if (ts_version and ts_version_from) or (not ts_version_from and not ts_version):
         fail("""Exactly one of 'ts_version' or 'ts_version_from' must be set.""")
 
@@ -140,7 +86,6 @@ def npm_dependencies(ts_version_from = None, ts_version = None, ts_integrity = N
         http_archive_version,
         name = "npm_typescript",
         bzlmod = bzlmod,
-        check_for_updates = check_for_updates,
         version = ts_version,
         version_from = ts_version_from,
         integrity = ts_integrity,

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -48,7 +48,7 @@ def rules_ts_bazel_dependencies():
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
     )
 
-def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None, check_for_updates = True):
+def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None):
     """Dependencies needed by users of rules_ts.
 
     To skip fetching the typescript package, call `rules_ts_bazel_dependencies` instead.
@@ -70,22 +70,6 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
             By default, uses values mirrored into rules_ts.
             For example, to get the integrity of version 4.6.3 you could run
             `curl --silent https://registry.npmjs.org/typescript/4.6.3 | jq -r '.dist.integrity'`
-        check_for_updates: Whether to check for newer releases of rules_ts and notify the user with
-            a log message when an update is available.
-
-            Note, to better understand our users, we also include basic information about the build
-            in the request to the update server. This never includes confidential or
-            personally-identifying information (PII). The values sent are:
-
-            - Currently used version. Helps us understand which older release(s) users are stuck on.
-            - bzlmod (true/false). Helps us roll out this feature which is mandatory by Bazel 9.
-            - Some CI-related environment variables to understand usage:
-                - BUILDKITE_ORGANIZATION_SLUG
-                - CIRCLE_PROJECT_USERNAME (this is *not* the username of the logged in user)
-                - GITHUB_REPOSITORY_OWNER
-                - BUILDKITE_BUILD_NUMBER
-                - CIRCLE_BUILD_NUM
-                - GITHUB_RUN_NUMBER
     """
 
     rules_ts_bazel_dependencies()
@@ -94,5 +78,4 @@ def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrit
         ts_version_from = ts_version_from,
         ts_version = ts_version,
         ts_integrity = ts_integrity,
-        check_for_updates = check_for_updates,
     )


### PR DESCRIPTION
It hasn't resulted in anyone knowing that a rules_ts upgrade was available. The CDN traffic from this is the vast majority of what we are serving. We never decided to roll it out to any other rulesets, so I feel that the experiment has failed. I also never finished the server-side code that responds to the requests.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

**For changes visible to end-users**

- Breaking change (this change will force users to change their own code or config)

The `check_for_updates` attribute on repository rules is removed. If you had set `check_for_updates = False` you may simply remove it.

### Test plan

- Covered by existing test cases
