### PR TITLE
perf: use starlark string.removeprefix

### DIFF
--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -164,15 +164,12 @@ def _join(*elements):
         return "/".join(segments)
     return "."
 
-def _strip_external(path):
-    return path[len("external/"):] if path.startswith("external/") else path
-
 def _relative_to_package(path, ctx):
-    for prefix in [ctx.bin_dir.path, ctx.label.workspace_name, ctx.label.package]:
-        prefix += "/"
-        path = _strip_external(path)
-        if path.startswith(prefix):
-            path = path[len(prefix):]
+    # TODO: "external/" should only be needed to be removed once
+    path = path.removeprefix("external/").removeprefix(ctx.bin_dir.path + "/")
+    path = path.removeprefix("external/").removeprefix(ctx.label.workspace_name + "/")
+    if ctx.label.package:
+        path = path.removeprefix("external/").removeprefix(ctx.label.package + "/")
     return path
 
 def _is_typings_src(src):


### PR DESCRIPTION
I think this is even in 5.1 and ok for rules_ts? https://github.com/bazelbuild/bazel/commit/50bb742fc35c04ab422a7ce723160b27d6900e6c

---

### Type of change

- Refactor (a code change that neither fixes a bug or adds a new feature)
- Performance (a code change that improves performance)

### Test plan

- Covered by existing test cases
