### PR TITLE
chore: fix GHA concurrency check to not apply to main branch

### DIFF
--- a/.github/workflows/aspect-workflows.yaml
+++ b/.github/workflows/aspect-workflows.yaml
@@ -10,6 +10,12 @@ on:
     # Allow this to be triggered manually via the GitHub UI Actions tab
     workflow_dispatch:
 
+concurrency:
+    # Cancel previous actions from the same PR or branch except 'main' branch.
+    # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.
+    group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}${{ github.ref_name == 'main' && format('::{0}', github.run_id) || ''}}
+    cancel-in-progress: ${{ github.ref_name != 'main' }}
+
 jobs:
     aspect-workflows:
         name: Aspect Workflows

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,10 @@ on:
     workflow_dispatch:
 
 concurrency:
-    # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
-    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
+    # Cancel previous actions from the same PR or branch except 'main' branch.
+    # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.
+    group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}${{ github.ref_name == 'main' && format('::{0}', github.run_id) || ''}}
+    cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
     # matrix-prep-* steps dynamically generate a bit of JSON depending on whether our action has


### PR DESCRIPTION
Tested this pattern in rules_jasmine. Already landed there.

Same as https://github.com/aspect-build/bazel-lib/pull/771.