### PR TITLE
fix: typecheck_test depends on the .d.ts files

### DIFF
--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -1,7 +1,15 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
 
 write_source_file(
     name = "aspect_workflows_reusable",
     in_file = "@aspect_workflows_action//:.github/workflows/.aspect-workflows-reusable.yaml",
     out_file = ".aspect-workflows-reusable.yaml",
+)
+
+bzl_library(
+    name = "deps",
+    srcs = ["deps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
 )

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -146,6 +146,7 @@ bzl_library(
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//ts/private:build_test",
         "//ts/private:options",
         "//ts/private:ts_config",
         "//ts/private:ts_project",

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -8,7 +8,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
 load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//ts/private:build_test.bzl", "build_test")
 load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")
 load("//ts/private:ts_lib.bzl", _lib = "lib")
 load("//ts/private:ts_project.bzl", _ts_project = "ts_project")
@@ -372,6 +372,7 @@ def ts_project(
             name = test_target_name,
             targets = [typecheck_target_name],
             tags = common_kwargs.get("tags"),
+            size = "small",
             visibility = common_kwargs.get("visibility"),
         )
 

--- a/ts/private/BUILD.bazel
+++ b/ts/private/BUILD.bazel
@@ -84,6 +84,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "build_test",
+    srcs = ["build_test.bzl"],
+    visibility = ["//ts:__subpackages__"],
+)
+
+bzl_library(
     name = "options",
     srcs = ["options.bzl"],
     visibility = ["//ts:__subpackages__"],

--- a/ts/private/build_test.bzl
+++ b/ts/private/build_test.bzl
@@ -1,0 +1,35 @@
+"""Fork of @bazel_skylib//rules:build_test.bzl
+
+Workaround for https://github.com/bazelbuild/bazel-skylib/issues/480
+"""
+
+_DOC = """\
+build_test is a trivial test that always passes.
+
+It is used to force Bazel to build some of its dependencies, in the case where
+`--build_tests_only` would have otherwise caused those to be skipped.
+"""
+
+def _build_test_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.write(
+        output = executable,
+        is_executable = True,
+        content = "#!/usr/bin/env bash\nexit 0",
+    )
+
+    return DefaultInfo(
+        files = depset([executable]),
+        executable = executable,
+        # The critical fix, so that the test inputs include the default outputs of the targets to check
+        runfiles = ctx.runfiles(files = ctx.files.targets),
+    )
+
+build_test = rule(
+    doc = _DOC,
+    implementation = _build_test_impl,
+    attrs = {
+        "targets": attr.label_list(allow_files = True),
+    },
+    test = True,
+)

--- a/ts/private/build_test.bzl
+++ b/ts/private/build_test.bzl
@@ -12,6 +12,7 @@ It is used to force Bazel to build some of its dependencies, in the case where
 
 def _build_test_impl(ctx):
     executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+
     ctx.actions.write(
         output = executable,
         is_executable = True,


### PR DESCRIPTION
Fixes #567
workaround for https://github.com/bazelbuild/bazel-skylib/issues/480

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
