### PR TITLE
chore: fix buildifier error

### DIFF
--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 write_source_file(
     name = "aspect_workflows_reusable",


### PR DESCRIPTION
I think this was broken in f5df58cf2f036c45901394e9305526e2a9e4f616.