### PR TITLE
feat: support incompatible_enable_proto_toolchain_resolution

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,13 +12,12 @@ bazel_dep(name = "aspect_rules_js", version = "1.34.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 
-# Only needed because rules_proto doesn't provide the protoc toolchain yet.
-# TODO(alex/sahin): remove in the future
+# TODO(4.x): remove support for non-toolchainized protoc
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 
 # Similar to rules_python/MODULE.bazel, see https://github.com/bazelbuild/rules_python/pull/832
 # These are loaded only when using ts_proto_library
-bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+bazel_dep(name = "rules_proto", version = "6.0.0")
 
 ####### Dev dependencies ########
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,6 +102,10 @@ npm_repositories()
 # bazel run -- @npm_typescript//:tsc --version
 rules_ts_dependencies(ts_version_from = "@npm//examples:typescript/resolved.json")
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 ###########################################
 # Protobuf rules to test ts_proto_library
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")

--- a/e2e/bzlmod/.bazelrc
+++ b/e2e/bzlmod/.bazelrc
@@ -9,6 +9,8 @@ import %workspace%/../../.aspect/bazelrc/performance.bazelrc
 ### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
 common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+# NB: comment this line out to test the legacy path to @com_google_protobuf//:protoc
+common --incompatible_enable_proto_toolchain_resolution
 
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -8,6 +8,7 @@ local_path_override(
 bazel_dep(name = "aspect_rules_js", version = "1.34.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7", dev_dependency = True)
+bazel_dep(name = "toolchains_protoc", version = "0.2.4", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -38,6 +38,13 @@ def rules_ts_internal_deps():
     )
 
     http_archive(
+        name = "bazel_features",
+        sha256 = "2cd9e57d4c38675d321731d65c15258f3a66438ad531ae09cb8bb14217dc8572",
+        strip_prefix = "bazel_features-1.11.0",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz",
+    )
+
+    http_archive(
         name = "rules_proto",
         sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
         strip_prefix = "rules_proto-6.0.0",

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -39,11 +39,9 @@ def rules_ts_internal_deps():
 
     http_archive(
         name = "rules_proto",
-        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-        strip_prefix = "rules_proto-5.3.0-21.7",
-        urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-        ],
+        sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
+        strip_prefix = "rules_proto-6.0.0",
+        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_proto/discussions/213

---

### Changes are visible to end-users: no

It will cause bzlmod users to get rules_proto 6.0.0 in their resolved dependencies, which is technically breaking.

### Test plan

- Covered by existing test cases

Note, we could add automated e2e testing for the `--noincompatible_enable_proto_toolchain_resolution` path as well - feels like overkill given that the conditional logic is all using upstream helpers