### PR TITLE
fix: don't limit extends on ts_project to only .json files

### DIFF
--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -114,7 +114,7 @@ COMPILER_OPTION_ATTRS = {
         doc = "https://www.typescriptlang.org/tsconfig#emitDeclarationOnly",
     ),
     "extends": attr.label(
-        allow_files = [".json"],
+        allow_files = True,
         doc = "https://www.typescriptlang.org/tsconfig#extends",
     ),
     "incremental": attr.bool(


### PR DESCRIPTION
A user may want to supply an npm package such as `//:node_modules/tsconfig` to `extends` attribute
