### PR TITLE
chore: bump to rules_js 2.0.0-rc1 and minimum aspect_bazel_lib 2.7.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,8 +7,8 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.6")
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0", dev_dependency = True)  # repeated here only because we use the platforms definitions for rbe
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1", dev_dependency = True)  # repeated here only because we use the platforms definitions for rbe
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7", dev_dependency = True)
 bazel_dep(name = "toolchains_protoc", version = "0.2.4", dev_dependency = True)

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
 # no such package '@[unknown repo 'aspect_rules_js' requested from @]//platforms':
 # The repository '@[unknown repo 'aspect_rules_js' requested from @]' could not be resolved:
 # No repository visible as '@aspect_rules_js' from main repository
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)

--- a/e2e/external_dep/app/MODULE.bazel
+++ b/e2e/external_dep/app/MODULE.bazel
@@ -5,7 +5,7 @@ local_path_override(
 )
 
 # TODO: see note on rules_js in the parent MODULE.bazel
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -4,8 +4,8 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.6", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc0", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -30,16 +30,16 @@ def rules_ts_bazel_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "b59781939f40c8bf148f4a71bd06e3027e15e40e98143ea5688b83531ec8528f",
-        strip_prefix = "bazel-lib-2.7.6",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.6/bazel-lib-v2.7.6.tar.gz",
+        sha256 = "6d758a8f646ecee7a3e294fbe4386daafbe0e5966723009c290d493f227c390b",
+        strip_prefix = "bazel-lib-2.7.7",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "389021e29b3aeed2f6fb3a7a1478f8fc52947a6500b198a7ec0f3358c2842415",
-        strip_prefix = "rules_js-2.0.0-rc0",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc0/rules_js-v2.0.0-rc0.tar.gz",
+        sha256 = "7085e915cdba6f2dc0ce93bef59f5d040a539b510b840456b6ac7ccc2bee7886",
+        strip_prefix = "rules_js-2.0.0-rc1",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc1/rules_js-v2.0.0-rc1.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
aspect_bazel_lib min bump goes along with rules_js bump in https://github.com/aspect-build/rules_js/pull/1763 to pick up fix for copy_to_directory that affects npm_package: https://github.com/aspect-build/bazel-lib/pull/857.