### PR TITLE
Example on bazel failing when 2 ts_proto_library are in a single BUILD file

### DIFF
--- a/examples/proto_grpc/BUILD.bazel
+++ b/examples/proto_grpc/BUILD.bazel
@@ -17,6 +17,15 @@ proto_library(
     ],
 )
 
+proto_library(
+    name = "status_proto",
+    srcs = ["status.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+    ],
+)
+
 ts_proto_library(
     name = "logger_ts_proto",
     node_modules = ":node_modules",
@@ -25,10 +34,20 @@ ts_proto_library(
     deps = ["//examples/connect_node/proto"],
 )
 
+ts_proto_library(
+    name = "status_ts_proto",
+    node_modules = ":node_modules",
+    proto = ":status_proto",
+    visibility = ["//visibility:public"],
+)
+
 ts_project(
     name = "proto_grpc",
     srcs = ["main.ts"],
-    deps = [":logger_ts_proto"],
+    deps = [
+        ":logger_ts_proto",
+        ":status_ts_proto"
+    ],
 )
 
 js_test(

--- a/examples/proto_grpc/status.proto
+++ b/examples/proto_grpc/status.proto
@@ -1,0 +1,27 @@
+// https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto
+
+syntax = "proto3";
+
+package rpc;
+
+import "google/protobuf/any.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+message Status {
+  // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+  int32 code = 1;
+
+  // A developer-facing error message, which should be in English. Any
+  // user-facing error message should be localized and sent in the
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+  string message = 2;
+
+  // A list of messages that carry the error details.  There will be a
+  // common set of message types for APIs to use.
+  repeated google.protobuf.Any details = 3;
+}

--- a/ts/proto.bzl
+++ b/ts/proto.bzl
@@ -47,7 +47,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("//ts/private:ts_proto_library.bzl", ts_proto_library_rule = "ts_proto_library")
 
-def ts_proto_library(name, node_modules, gen_connect_es = True, gen_connect_query = False, gen_connect_query_service_mapping = {}, copy_files = True, files_to_copy = None, **kwargs):
+def ts_proto_library(name, node_modules, gen_connect_es = True, gen_connect_query = False, gen_connect_query_service_mapping = {}, copy_files = True, files_to_copy = None, proto_srcs = None, **kwargs):
     """
     A macro to generate JavaScript code and TypeScript typings from .proto files.
 
@@ -136,6 +136,8 @@ def ts_proto_library(name, node_modules, gen_connect_es = True, gen_connect_quer
     if not copy_files:
         return
     if not files_to_copy:
+        if not proto_srcs:
+            fail("no `proto_scrs`")
         proto_srcs = native.glob(["**/*.proto"])
         files_to_copy = [s.replace(".proto", "_pb.d.ts") for s in proto_srcs]
         if gen_connect_es:


### PR DESCRIPTION
error: `Error in directory_path: directory_path rule '_logger_pb.d.ts_dirpath' in package 'examples/proto_grpc' conflicts with existing directory_path rule`
