### PR TITLE
always set 'use_default_shell_env' in ctx.actions.run

### DIFF
--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -3,7 +3,8 @@ load("@aspect_bazel_lib//lib:bazelrc_presets.bzl", "write_aspect_bazelrc_presets
 write_aspect_bazelrc_presets(
     name = "update_aspect_bazelrc_presets",
     presets = [
-        "bazel6",
+        # Modified from upstream
+        # "bazel6",
         "bazel7",
     ],
 )

--- a/.github/workflows/bazel6.bazelrc
+++ b/.github/workflows/bazel6.bazelrc
@@ -33,3 +33,6 @@ query --noexperimental_check_output_files
 # NB: This flag is in bazel6.bazelrc because it became a no-op in Bazel 7 and has been removed
 # in Bazel 8.
 build --incompatible_remote_results_ignore_disk
+
+# Added in 6.4.0, see https://github.com/bazelbuild/bazel/pull/19319
+build --incompatible_merge_fixed_and_default_shell_env

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -342,6 +342,7 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             env = {
                 "BAZEL_BINDIR": ctx.bin_dir.path,
             },
+            use_default_shell_env = True,
         )
 
     transitive_sources = js_lib_helpers.gather_transitive_sources(output_sources, srcs_deps)

--- a/ts/private/ts_proto_library.bzl
+++ b/ts/private/ts_proto_library.bzl
@@ -65,6 +65,7 @@ def _protoc_action(ctx, proto_info, outputs):
             [ctx.executable.protoc_gen_connect_query] if ctx.attr.gen_connect_query else []
         ),
         env = {"BAZEL_BINDIR": ctx.bin_dir.path},
+        use_default_shell_env = True,
     )
 
 def _declare_outs(ctx, info, ext):

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -45,6 +45,7 @@ Assumes all tsconfig file deps are already copied to the bin directory.
         env = {
             "BAZEL_BINDIR": ctx.bin_dir.path,
         },
+        use_default_shell_env = True,
     )
 
     return [marker]


### PR DESCRIPTION
Aspect uses shell wrappers that invoke tools like `dirname` and `uname`. When the default shell env is not inherited, this prevents tools from being found on systems without a working fallback $PATH (like NixOS).

This might be incompatible with setting the `env` attribute, unless the bazel flag `--incompatible_merge_fixed_and_default_shell_env` is set on Bazel versions < 7.

See also: https://github.com/NixOS/nixpkgs/issues/289505

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
