### PR TITLE
chore: add --check_direct_dependencies to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,11 @@ build --repo_env=JAVA_HOME=../bazel_tools/jdk
 # verbose
 common:verbose --@aspect_rules_ts//ts:verbose --worker_verbose
 
+# Don’t want to push a rules author to update their deps if not needed.
+# https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies
+# https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
+common --check_direct_dependencies=off
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from


### PR DESCRIPTION
Setting this flag in our the rule sets we maintain. Don’t want to push a rules author to update their deps if not needed.

https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies

https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0