### PR TITLE
chore: bump minimum rules_nodejs to 6.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependenc
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
-bazel_dep(name = "rules_nodejs", version = "6.1.0", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "toolchains_protoc", version = "0.3.0", dev_dependency = True)
 

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -44,9 +44,9 @@ def rules_ts_bazel_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "dddd60acc3f2f30359bef502c9d788f67e33814b0ddd99aa27c5a15eb7a41b8c",
-        strip_prefix = "rules_nodejs-6.1.0",
-        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.0/rules_nodejs-v6.1.0.tar.gz",
+        sha256 = "87c6171c5be7b69538d4695d9ded29ae2626c5ed76a9adeedce37b63c73bef67",
+        strip_prefix = "rules_nodejs-6.2.0",
+        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz",
     )
 
 def rules_ts_dependencies(ts_version_from = None, ts_version = None, ts_integrity = None):


### PR DESCRIPTION
Ensures users pick up https://github.com/bazelbuild/rules_nodejs/pull/3760 fix which is a footgun that should be avoided.