### PR TITLE
chore: fix a TODO for 3.0.0

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -89,44 +89,6 @@ for srcs and tsconfig, and pre-declaring output files.
 | <a id="ts_project_rule-validator"></a>validator |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 
-<a id="validate_options"></a>
-
-## validate_options
-
-<pre>
-validate_options(<a href="#validate_options-name">name</a>, <a href="#validate_options-deps">deps</a>, <a href="#validate_options-allow_js">allow_js</a>, <a href="#validate_options-composite">composite</a>, <a href="#validate_options-declaration">declaration</a>, <a href="#validate_options-declaration_map">declaration_map</a>,
-                 <a href="#validate_options-emit_declaration_only">emit_declaration_only</a>, <a href="#validate_options-extends">extends</a>, <a href="#validate_options-incremental">incremental</a>, <a href="#validate_options-preserve_jsx">preserve_jsx</a>, <a href="#validate_options-resolve_json_module">resolve_json_module</a>,
-                 <a href="#validate_options-source_map">source_map</a>, <a href="#validate_options-target">target</a>, <a href="#validate_options-ts_build_info_file">ts_build_info_file</a>, <a href="#validate_options-tsconfig">tsconfig</a>, <a href="#validate_options-validator">validator</a>)
-</pre>
-
-DEPRECATED. Use Validation Actions instead.
-
-Validates that some tsconfig.json properties match attributes on ts_project.
-See the documentation of [`ts_project`](#ts_project) for more information.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="validate_options-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="validate_options-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
-| <a id="validate_options-allow_js"></a>allow_js |  https://www.typescriptlang.org/tsconfig#allowJs   | Boolean | optional |  `False`  |
-| <a id="validate_options-composite"></a>composite |  https://www.typescriptlang.org/tsconfig#composite   | Boolean | optional |  `False`  |
-| <a id="validate_options-declaration"></a>declaration |  https://www.typescriptlang.org/tsconfig#declaration   | Boolean | optional |  `False`  |
-| <a id="validate_options-declaration_map"></a>declaration_map |  https://www.typescriptlang.org/tsconfig#declarationMap   | Boolean | optional |  `False`  |
-| <a id="validate_options-emit_declaration_only"></a>emit_declaration_only |  https://www.typescriptlang.org/tsconfig#emitDeclarationOnly   | Boolean | optional |  `False`  |
-| <a id="validate_options-extends"></a>extends |  https://www.typescriptlang.org/tsconfig#extends   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="validate_options-incremental"></a>incremental |  https://www.typescriptlang.org/tsconfig#incremental   | Boolean | optional |  `False`  |
-| <a id="validate_options-preserve_jsx"></a>preserve_jsx |  https://www.typescriptlang.org/tsconfig#jsx   | Boolean | optional |  `False`  |
-| <a id="validate_options-resolve_json_module"></a>resolve_json_module |  https://www.typescriptlang.org/tsconfig#resolveJsonModule   | Boolean | optional |  `False`  |
-| <a id="validate_options-source_map"></a>source_map |  https://www.typescriptlang.org/tsconfig#sourceMap   | Boolean | optional |  `False`  |
-| <a id="validate_options-target"></a>target |  -   | String | optional |  `""`  |
-| <a id="validate_options-ts_build_info_file"></a>ts_build_info_file |  -   | String | optional |  `""`  |
-| <a id="validate_options-tsconfig"></a>tsconfig |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="validate_options-validator"></a>validator |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-
-
 <a id="TsConfigInfo"></a>
 
 ## TsConfigInfo

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -4,7 +4,6 @@ The most commonly used is the [ts_project](#ts_project) macro which accepts Type
 inputs and produces JavaScript or declaration (.d.ts) outputs.
 """
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
 load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@bazel_skylib//lib:partial.bzl", "partial")
@@ -12,22 +11,9 @@ load("//ts/private:build_test.bzl", "build_test")
 load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")
 load("//ts/private:ts_lib.bzl", _lib = "lib")
 load("//ts/private:ts_project.bzl", _ts_project = "ts_project")
-load("//ts/private:ts_validate_options.bzl", validate_lib = "lib")
 
 ts_config = _ts_config
 TsConfigInfo = _TsConfigInfo
-
-# TODO(3.0): remove this rule; not needed with validation actions
-validate_options = rule(
-    doc = """DEPRECATED. Use Validation Actions instead.
-    
-    Validates that some tsconfig.json properties match attributes on ts_project.
-    See the documentation of [`ts_project`](#ts_project) for more information.""",
-    implementation = validate_lib.implementation,
-    attrs = validate_lib.attrs,
-    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
-)
-
 ts_project_rule = _ts_project
 
 def _is_file_missing(label):

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -2,9 +2,7 @@
 
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action", "copy_files_to_bin_actions")
 load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
-load("@aspect_rules_js//js:providers.bzl", "JsInfo")
 load(":ts_config.bzl", "TsConfigInfo")
-load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS")
 
 def _tsconfig_inputs(ctx):
     """Returns all transitively referenced tsconfig files from "tsconfig" and "extends" attributes."""
@@ -20,31 +18,10 @@ def _tsconfig_inputs(ctx):
             inputs.append(ctx.attr.extends.files)
     return depset(transitive = inputs)
 
-# TODO(3.0): remove this along with the validate_options rule
-def _validate_options_impl(ctx):
-    # Provider validation
-    if not ctx.attr.allow_js:
-        for d in ctx.attr.deps:
-            if not d[JsInfo].types:
-                fail("""\
-ts_project '{1}' dependency '{0}' does does not contain any types (.d.ts or other type-check files).
-Generally, targets which produce no types aren't useful as dependencies to the TypeScript type-checker.
-This likely means you forgot to set 'declaration = true' in the compilerOptions for that target.
-
-To disable this check, set the validate attribute to False:
-  npx @bazel/buildozer 'set validate False' {1}
-""".format(d.label, ctx.attr.target))
-
-    inputs = _tsconfig_inputs(ctx)
-    return [
-        # https://bazel.build/extending/rules#validations_output_group
-        # "hold the otherwise unused outputs of validation actions"
-        OutputGroupInfo(_validation = depset(_validate_action(ctx, inputs.to_list()))),
-    ]
-
 def _validate_action(ctx, tsconfig_inputs):
-    # Bazel won't run our action unless its output is needed, so make a marker file
-    # We make it a .d.ts file so we can plumb it to the deps of the ts_project compile.
+    # Bazel validation actions must still produce an output file.
+    # Choose to make it a .d.ts file so it's possible to plumb it to the deps of the ts_project compile,
+    # even though validation action outputs don't need to be used anywhere.
     marker = ctx.actions.declare_file("%s.optionsvalid.d.ts" % ctx.label.name)
     tsconfig = copy_file_to_bin_action(ctx, ctx.file.tsconfig)
 
@@ -82,18 +59,7 @@ def _validate_action(ctx, tsconfig_inputs):
 
     return [marker]
 
-# TODO(3.0): remove this along with the validate_options rule
-_ATTRS = dict(COMPILER_OPTION_ATTRS, **{
-    "deps": attr.label_list(mandatory = True, providers = [JsInfo]),
-    "target": attr.string(),
-    "ts_build_info_file": attr.string(),
-    "tsconfig": attr.label(mandatory = True, allow_single_file = [".json"]),
-    "validator": attr.label(mandatory = True, executable = True, cfg = "exec"),
-})
-
 lib = struct(
-    attrs = _ATTRS,
-    implementation = _validate_options_impl,
     tsconfig_inputs = _tsconfig_inputs,
     validation_action = _validate_action,
 )


### PR DESCRIPTION
The 'validate_options' rule is no longer produced by our macro, so this is not a breaking change for most users. However the symbol was exported in the public API, so the next major release is our opportunity to remove it.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

The `validate_options` rule has been removed. This was typically not used directly by users, instead they relied on the `ts_project` macro to create such a rule, which it stopped doing in a 2.x release (https://github.com/aspect-build/rules_ts/releases/tag/v2.1.1)

Any users who had an explicit reference to this public API symbol should remove it, and rely on validation actions instead.

### Test plan

- Covered by existing test cases
