### PR TITLE
fix: pin typescript version in e2e test

### DIFF
--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -15,5 +15,5 @@ bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1", dev_dependency = True
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
-rules_ts_ext.deps()
+rules_ts_ext.deps(ts_version = "4.8.4")
 use_repo(rules_ts_ext, "npm_typescript")


### PR DESCRIPTION
We didn't mean to pick up LATEST by default.

Makes CI green again. I'll send a follow-up PR to update us to latest and deal with that breakage intentionally.