### PR TITLE
fix: join `--descriptor_set_in` with host path separator

### DIFF
--- a/ts/private/ts_proto_library.bzl
+++ b/ts/private/ts_proto_library.bzl
@@ -47,7 +47,7 @@ def _protoc_action(ctx, proto_info, outputs):
         args.add_joined(["--connect-query_out", ctx.bin_dir.path], join_with = "=")
 
     args.add("--descriptor_set_in")
-    args.add_joined(proto_info.transitive_descriptor_sets, join_with = ":")
+    args.add_joined(proto_info.transitive_descriptor_sets, join_with = ctx.configuration.host_path_separator)
 
     args.add_all(proto_info.direct_sources)
 

--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -4,12 +4,15 @@ load(":flags_test.bzl", "ts_project_flags_test_suite")
 load(":mock_transpiler.bzl", "mock")
 load(":transpiler_tests.bzl", "transpiler_test_suite")
 load(":ts_project_test.bzl", "ts_project_test_suite")
+load(":ts_proto_library_test.bzl", "ts_proto_library_test_suite")
 
 transpiler_test_suite()
 
 ts_project_test_suite(name = "ts_project_test")
 
 ts_project_flags_test_suite(name = "ts_project_flags_test")
+
+ts_proto_library_test_suite(name = "ts_proto_library_test")
 
 # Ensure that when determining output location, the `root_dir` attribute is only removed once.
 ts_project(

--- a/ts/test/ts_proto_library/BUILD.bazel
+++ b/ts/test/ts_proto_library/BUILD.bazel
@@ -3,8 +3,6 @@
 # since protoc would otherwise not find the proto files in the descriptor
 # database.
 
-load("//ts:proto.bzl", "ts_proto_library")
-
 proto_library(
     name = "bar_proto",
     srcs = [

--- a/ts/test/ts_proto_library/BUILD.bazel
+++ b/ts/test/ts_proto_library/BUILD.bazel
@@ -1,0 +1,27 @@
+"Proto libraries for ts_proto_library tests."
+# These are a concrete package rather than using `write_file` in the test file,
+# since protoc would otherwise not find the proto files in the descriptor
+# database.
+
+load("//ts:proto.bzl", "ts_proto_library")
+
+proto_library(
+    name = "bar_proto",
+    srcs = [
+        ":bar.proto",
+    ],
+    tags = ["manual"],
+    visibility = ["//ts/test:__subpackages__"],
+)
+
+proto_library(
+    name = "foo_proto",
+    srcs = [
+        ":foo.proto",
+    ],
+    tags = ["manual"],
+    visibility = ["//ts/test:__subpackages__"],
+    deps = [
+        ":bar_proto",
+    ],
+)

--- a/ts/test/ts_proto_library/bar.proto
+++ b/ts/test/ts_proto_library/bar.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package bar;
+
+message Bar {}

--- a/ts/test/ts_proto_library/foo.proto
+++ b/ts/test/ts_proto_library/foo.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package foo;
+
+import "ts/test/ts_proto_library/bar.proto";
+
+message Foo {
+  bar.Bar bar = 1;
+}

--- a/ts/test/ts_proto_library_test.bzl
+++ b/ts/test/ts_proto_library_test.bzl
@@ -1,9 +1,6 @@
 "UnitTest for ts_proto_library"
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//ts:proto.bzl", "ts_proto_library")
 
 def ts_proto_library_test_suite(name):

--- a/ts/test/ts_proto_library_test.bzl
+++ b/ts/test/ts_proto_library_test.bzl
@@ -1,0 +1,33 @@
+"UnitTest for ts_proto_library"
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//ts:proto.bzl", "ts_proto_library")
+
+def ts_proto_library_test_suite(name):
+    """Test suite including all tests and data.
+
+    Args:
+        name: The name of the test suite.
+    """
+
+    ts_proto_library(
+        name = "ts_proto_library_with_dep",
+        # The //examples package is the root pnpm package for the repo, so we
+        # borrow from the proto/grpc example to provide the required
+        # ts_proto_library npm dependencies.
+        node_modules = "//examples/proto_grpc:node_modules",
+        proto = "//ts/test/ts_proto_library:foo_proto",
+        proto_srcs = ["//ts/test/ts_proto_library:foo.proto"],
+        # This is disabled to avoid checking in the output files, which are
+        # implicitly inputs for the copy_file tests.
+        copy_files = False,
+        tags = ["manual"],
+    )
+
+    build_test(
+        name = "ts_proto_library_with_dep_test",
+        targets = [":ts_proto_library_with_dep"],
+    )


### PR DESCRIPTION
Fixes #670.

As described in #670, protoc splits the arguments to `--proto_path` and `--descriptor_set_in` using an OS-specific path-separator. On posix, this is `:`, but on Windows this is `;`. The protobuf library takes the approach for its bazel rules to join on `ctx.configuration.host_path_separator`, so I've taken the same approach here as well.

---

### Changes are visible to end-users: no

### Test plan
- Manual testing; please provide instructions so we can reproduce:
https://github.com/AchilleaResearch/rules_ts_667/tree/repro_670 demonstrates the fix as a patch. `bazel build //:foo_ts_pb` on Windows with and without the patch https://github.com/AchilleaResearch/rules_ts_667/blob/repro_670/MODULE.bazel#L47
