### PR TITLE
fix(ts_proto_library): Depend on @bufbuild/protobuf

### DIFF
--- a/ts/proto.bzl
+++ b/ts/proto.bzl
@@ -88,7 +88,10 @@ def ts_proto_library(name, node_modules, proto, protoc_gen_options = {}, gen_con
     )
     js_binary(
         name = protoc_gen_es_target,
-        data = [node_modules + "/@bufbuild/protoc-gen-es"],
+        data = [
+            node_modules + "/@bufbuild/protoc-gen-es",
+            node_modules + "/@bufbuild/protobuf",
+        ],
         entry_point = protoc_gen_es_entry,
     )
 


### PR DESCRIPTION
Adds the peer dependency of proto-gen-es to the
deps of the js_binary used to run it

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
Tested on my local repo which was experiencing the module resolution error