### PR TITLE
perf: reduce use of join in _to_out_path

### DIFF
--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -208,8 +208,8 @@ def _to_out_path(f, out_dir, root_dir):
     f = f[f.find(":") + 1:]
     if root_dir:
         f = f.removeprefix(root_dir + "/")
-    if out_dir:
-        f = _join(out_dir, f)
+    if out_dir and out_dir != ".":
+        f = out_dir + "/" + f
     return f
 
 def _to_js_out_paths(srcs, out_dir, root_dir, allow_js, resolve_json_module, ext_map):


### PR DESCRIPTION
This function becomes 2-3x faster, saving around 100ms of analysis time at Airtable

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
