### PR TITLE
perf: remove unnecessary tsconfig relative_file computation

### DIFF
--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -137,10 +137,15 @@ def _write_tsconfig_rule(ctx):
 
     filtered_files = _filter_input_files(ctx.files.files, ctx.attr.allow_js, ctx.attr.resolve_json_module)
     if filtered_files:
-        content = content.replace(
-            "\"__files__\"",
-            str([relative_file(f.short_path, ctx.outputs.out.short_path) for f in filtered_files]),
-        )
+        # Update file paths to be relative to the tsconfig file, including a ./ prefix
+        # to ensure paths are all relative to the config file.
+        package_prefix = ctx.label.package + "/"
+        filtered_files = [
+            "./" + f.short_path.removeprefix(package_prefix)
+            for f in filtered_files
+        ]
+
+        content = content.replace("\"__files__\"", str(filtered_files))
     ctx.actions.write(
         output = ctx.outputs.out,
         content = content,


### PR DESCRIPTION
The tsconfig is only generated within the BUILD directory and there is an assert that the `srcs` are all within that directory, so the relative file paths are easy to compute.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
