### PR TITLE
refactor: change typechecking validation action to output group

### DIFF
--- a/e2e/test/validation.bats
+++ b/e2e/test/validation.bats
@@ -10,14 +10,14 @@ teardown() {
 }
 
 
-@test 'When tsc is only used for type-checking with a type-error, should pass when validations are disabled' {
+@test 'When tsc is only used for type-checking with a type-error, should pass when [name]_typecheck target not built' {
     workspace
 
     echo "export const a: string = 1;" > ./source.ts
     tsconfig --declaration
     ts_project --transpiler-mock --declaration --src "source.ts"
 
-    run bazel build :foo --norun_validations
+    run bazel build :foo
     assert_success
     run cat bazel-bin/source.js
     assert_success
@@ -25,14 +25,14 @@ teardown() {
     assert_output -p 'export const a: string = 1;'
 }
 
-@test 'When tsc is only used for type-checking with a type-error, should fail when validations are enabled' {
+@test 'When tsc is only used for type-checking with a type-error, should fail when [name]_typecheck target built' {
     workspace
 
     echo "export const a: string = 1;" > ./source.ts
     tsconfig --no-emit
-    ts_project --no-emit --src "source.ts"
+    ts_project --transpiler-mock --no-emit --src "source.ts"
     
-    run bazel build :foo --run_validations
+    run bazel build :foo_typecheck
     assert_failure
     assert_output -p "error TS2322: Type 'number' is not assignable to type 'string'"
 }


### PR DESCRIPTION
This way tsc is not forced to always run as a validation action in the background and instead invoked only when the `*_typecheck` test is run.

Currently this only effects the `noEmit` case.

In the future this will allow the `isolatedDeclarations` fast-path to avoid running type-checking at all unless `bazel test` is run. This way something such as `ibazel run //devserver` will not be blocked waiting for the validation action to run in the background.

---

### Changes are visible to end-users:no

### Test plan

- Covered by existing test cases
