### PR TITLE
fix: do not rely on @npm_typescript if custom tsc is provided

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -379,6 +379,17 @@ def ts_project(
     if tsc != _tsc and tsc_worker == _tsc_worker:
         supports_workers = 0
 
+    # Disable typescript version detection if tsc is not the default:
+    # - it would be wrong anyways
+    # - it is only used to warn if worker support is configured incorrectly.
+    if tsc != _tsc:
+        is_typescript_5_or_greater = None
+    else:
+        is_typescript_5_or_greater = select({
+            "@npm_typescript//:is_typescript_5_or_greater": True,
+            "//conditions:default": False,
+        })
+
     ts_project_rule(
         name = tsc_target_name,
         srcs = srcs,
@@ -411,10 +422,7 @@ def ts_project(
         tsc_worker = tsc_worker,
         transpile = -1 if not transpiler else int(transpiler == "tsc"),
         supports_workers = supports_workers,
-        is_typescript_5_or_greater = select({
-            "@npm_typescript//:is_typescript_5_or_greater": True,
-            "//conditions:default": False,
-        }),
+        is_typescript_5_or_greater = is_typescript_5_or_greater,
         validate = validate,
         validator = validator,
         **kwargs


### PR DESCRIPTION
This is a follow-up to #675 which made the `@npm_typescript` repository less special.

This replaces the (hopefully) last occurrence of this special name that cannot be changed by configuration.

Alternatives I considered:

- Expose the `is_typescript_5_or_greater` flag on the `ts_project` macro: Simplest option at first, but since it is only used for config validation, that would become nonsensical.
- Add a `npm_typescript_package` or `npm_typescript_repository` parameter that would allow overriding all places where `@npm_typescript//` is used by default: Would offer more functionality (e.g. worker config checking), but would also be more invasive.

---

### Changes are visible to end-users: yes

The change might make an incorrect warning disappear.

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no (no suggested additional release notes)

### Test plan

- Covered by existing test cases