### PR TITLE
chore: upgrade bazel-lib in e2e tests for windows fix

### DIFF
--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -4,6 +4,9 @@ local_path_override(
     path = "../..",
 )
 
+# Override the version declared by rules_ts for windows fix
+bazel_dep(name = "aspect_bazel_lib", version = "2.9.0", dev_dependency = True)
+
 # TODO: rules_js shouldn't be required in this module, as we don't reference it anywhere.
 # However, on RBE only (!) we get an error:
 # ERROR: /home/runner/work/rules_ts/rules_ts/e2e/external_dep/app/BUILD:4:11:

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -4,6 +4,14 @@ local_repository(
     path = "../..",
 )
 
+# Override the version declared by rules_ts for windows fix
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
+    strip_prefix = "bazel-lib-2.9.0",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
+)
+
 #---SNIP--- Below here is re-used in the workspace snippet published on releases
 
 ##################


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
