### PR TITLE
chore: upgrade bazel-lib in e2e tests for windows fix

### DIFF
--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -4,6 +4,12 @@ local_path_override(
     path = "../..",
 )
 
+# Override the version declared by rules_ts for windows fix
+single_version_override(
+    module_name = "aspect_bazel_lib",
+    version = "2.9.0",
+)
+
 # TODO: rules_js shouldn't be required in this module, as we don't reference it anywhere.
 # However, on RBE only (!) we get an error:
 # ERROR: /home/runner/work/rules_ts/rules_ts/e2e/external_dep/app/BUILD:4:11:

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -1,6 +1,16 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 local_repository(
     name = "aspect_rules_ts",
     path = "../..",
+)
+
+# Override the version declared by rules_ts for windows fix
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
+    strip_prefix = "bazel-lib-2.9.0",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")

--- a/e2e/external_dep/app/MODULE.bazel
+++ b/e2e/external_dep/app/MODULE.bazel
@@ -4,6 +4,12 @@ local_path_override(
     path = "../../..",
 )
 
+# Override the version declared by rules_ts for windows fix
+single_version_override(
+    module_name = "aspect_bazel_lib",
+    version = "2.9.0",
+)
+
 # TODO: see note on rules_js in the parent MODULE.bazel
 bazel_dep(name = "aspect_rules_js", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)

--- a/e2e/external_dep/app/WORKSPACE
+++ b/e2e/external_dep/app/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 local_repository(
     name = "aspect_rules_ts",
     path = "../../..",
@@ -6,6 +8,14 @@ local_repository(
 local_repository(
     name = "lib_wksp",
     path = "..",
+)
+
+# Override the version declared by rules_ts for windows fix
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
+    strip_prefix = "bazel-lib-2.9.0",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")

--- a/e2e/workspace/WORKSPACE
+++ b/e2e/workspace/WORKSPACE
@@ -1,7 +1,17 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # Override http_archive for local testing
 local_repository(
     name = "aspect_rules_ts",
     path = "../..",
+)
+
+# Override the version declared by rules_ts for windows fix
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
+    strip_prefix = "bazel-lib-2.9.0",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
 )
 
 #---SNIP--- Below here is re-used in the workspace snippet published on releases


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
