### PR TITLE
Support TypeScript workers with isolated declarations and custom TypeScript

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -373,17 +373,19 @@ def ts_project(
     if transpile_target_name or declarations_target_name:
         tsc_target_name = "%s_tsc" % name
 
-        lib_srcs = []
+        # Always include tsc target since even if it doesn't output js+dts, it may
+        # still be needed for JSON files to be included in the sources. Downstream
+        # dependencies of the js_library won't inadvertently cause this target to be
+        # typechecked when both transpiler targets for js+dts are present because
+        # the js_library doesn't include the ".typecheck" file which is only in the
+        # "typecheck" output group.
+        lib_srcs = [tsc_target_name]
 
         # Include the transpiler targets for both js+dts if they exist.
         if transpile_target_name:
             lib_srcs.append(transpile_target_name)
         if declarations_target_name:
             lib_srcs.append(declarations_target_name)
-
-        # If tsc outputs anything (js or dts) then it should be included in the srcs.
-        if not (transpile_target_name and declarations_target_name):
-            lib_srcs.append(tsc_target_name)
 
         # Include direct & transitive deps in addition to transpiled sources so
         # that this js_library can be a valid dep for downstream ts_project or other rules_js derivative rules.

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -442,7 +442,7 @@ def ts_project(
     # Disable typescript version detection if tsc is not the default:
     # - it would be wrong anyways
     # - it is only used to warn if worker support is configured incorrectly.
-    if tsc != _tsc:
+    if tsc != _tsc or tsc_worker != _tsc_worker:
         is_typescript_5_or_greater = None
     else:
         is_typescript_5_or_greater = select({

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -234,12 +234,18 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
         args = ctx.actions.args()
         args.add_all(common_args)
 
+        args.add("--noEmit")
+
+        env = {
+            "BAZEL_BINDIR": ctx.bin_dir.path,
+        }
+
         if supports_workers:
             args.use_param_file("@%s", use_always = True)
             args.set_param_file_format("multiline")
             args.add("--bazelValidationFile", typecheck_output.short_path)
-
-        args.add("--noEmit")
+        else:
+            env["JS_BINARY__STDOUT_OUTPUT_FILE"] = typecheck_output.path
 
         ctx.actions.run(
             executable = executable,
@@ -253,10 +259,7 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
                 ctx.label,
                 tsconfig_path,
             ),
-            env = {
-                "BAZEL_BINDIR": ctx.bin_dir.path,
-                "JS_BINARY__STDOUT_OUTPUT_FILE": typecheck_output.path,
-            },
+            env = env,
         )
     else:
         typecheck_outs.extend(output_types)


### PR DESCRIPTION
I've successfully tested this on Airtable's code base. Memory usage can be a problem when typechecking a lot of targets. Something like what @alexeagle requested in https://github.com/bazelbuild/bazel/issues/12165#issuecomment-769207271 might be useful. I'm still playing around with `--experimental_total_worker_memory_limit_mb` and `--experimental_shrink_worker_pool` to see if they can prevent OOMs.

Also, I don't know why, but I have not encountered https://github.com/aspect-build/rules_ts/issues/361 and I don't believe any changes in this PR would have done anything to fix that issue.