### PR TITLE
Add fixture for declaration transpiler test

### DIFF
--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -1,7 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//ts:defs.bzl", "ts_project")
 load(":flags_test.bzl", "ts_project_flags_test_suite")
-load(":mock_transpiler.bzl", "mock")
+load(":mock_declaration_transpiler.bzl", mock_declaration_transpiler = "mock")
+load(":mock_transpiler.bzl", mock_transpiler = "mock")
 load(":transpiler_tests.bzl", "transpiler_test_suite")
 load(":ts_project_test.bzl", "ts_project_test_suite")
 
@@ -15,8 +16,9 @@ ts_project_flags_test_suite(name = "ts_project_flags_test")
 ts_project(
     name = "rootdir_works_with_repeated_directory",
     srcs = ["root/deep/root/deep_src.ts"],
+    declaration_transpiler = mock_declaration_transpiler,
     root_dir = "root",
-    transpiler = mock,
+    transpiler = mock_transpiler,
     tsconfig = {
         "compilerOptions": {
             "declaration": True,
@@ -30,4 +32,10 @@ bzl_library(
     srcs = ["mock_transpiler.bzl"],
     visibility = ["//visibility:public"],
     deps = ["@aspect_rules_ts//ts/private:ts_lib"],
+)
+
+bzl_library(
+    name = "mock_declaration_transpiler",
+    srcs = ["mock_declaration_transpiler.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/ts/test/mock_declaration_transpiler.bzl
+++ b/ts/test/mock_declaration_transpiler.bzl
@@ -1,0 +1,61 @@
+"Fixture to demonstrate a custom declaration transpiler for ts_project"
+
+load("@aspect_rules_js//js:providers.bzl", "JsInfo")
+load("@aspect_rules_ts//ts/private:ts_lib.bzl", "lib")
+
+def _mock_impl(ctx):
+    out_files = []
+
+    for src in ctx.files.srcs:
+        out_path = src.short_path
+
+        if out_path.endswith(".json"):
+            continue
+
+        dts_file = ctx.actions.declare_file(lib.relative_to_package(out_path.replace(".ts", ".d.ts"), ctx))
+        out_files.append(dts_file)
+
+        ctx.actions.run_shell(
+            inputs = [src],
+            outputs = [dts_file],
+            command = "cp $@",
+            arguments = [src.path, dts_file.path],
+        )
+
+    output_types_depset = depset(out_files)
+
+    return [
+        JsInfo(
+            target = ctx.label,
+            sources = depset(),
+            types = output_types_depset,
+            transitive_sources = depset(),
+            transitive_types = depset(),
+            npm_sources = depset(),
+            npm_package_store_infos = depset(),
+        ),
+        DefaultInfo(
+            files = output_types_depset,
+        ),
+    ]
+
+mock_impl = rule(
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "TypeScript source files",
+            allow_files = True,
+            mandatory = True,
+        ),
+    },
+    implementation = _mock_impl,
+)
+
+def mock(name, srcs, **kwargs):
+    # Run the rule producing those pre-declared outputs as well as any other outputs
+    # which can not be determined ahead of time such as within directories, grouped
+    # within a filegroup() etc.
+    mock_impl(
+        name = name,
+        srcs = srcs,
+        **kwargs
+    )


### PR DESCRIPTION
I haven't quite figured out how or what to test, but I figure adding a dummy transpiler based on what we have at Airtable could be helpful.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases