### PR TITLE
fix: make `//ts:skipLibCheck` flag public

### DIFF
--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -66,6 +66,7 @@ string_flag(
         "honor_tsconfig",
         "unspecified",
     ],
+    visibility = ["//visibility:public"],
 )
 
 bool_flag(


### PR DESCRIPTION
Likely an oversight: all other flags below are public.

We would like to alias this flag to hide the rules_ts dependency and cannot because of the visibility.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: Doc update IMO unnecessary.
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases