### PR TITLE
feat: add transitive typecheck output group

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -370,7 +370,9 @@ def ts_project(
     if not emit_tsc_js or not emit_tsc_dts:
         types_target_name = "%s_types" % name
         typecheck_target_name = "%s_typecheck" % name
+        transitive_typecheck_target_name = "%s_transitive_typecheck" % name
         test_target_name = "%s_typecheck_test" % name
+        transitive_typecheck_test_target_name = "%s_transitive_typecheck_test" % name
 
         # Users should build this target to get typing files
         if not no_emit:
@@ -397,10 +399,26 @@ def ts_project(
             **common_kwargs
         )
 
+        # Users should build this target to get a failed build when typechecking fails
+        native.filegroup(
+            name = transitive_typecheck_target_name,
+            srcs = [name],
+            output_group = "transitive_typecheck",
+            **common_kwargs
+        )
+
         # Ensures the typecheck target gets built under `bazel test --build_tests_only`
         build_test(
             name = test_target_name,
             targets = [typecheck_target_name],
+            tags = common_kwargs.get("tags"),
+            size = "small",
+            visibility = common_kwargs.get("visibility"),
+        )
+
+        build_test(
+            name = transitive_typecheck_test_target_name,
+            targets = [transitive_typecheck_target_name],
             tags = common_kwargs.get("tags"),
             size = "small",
             visibility = common_kwargs.get("visibility"),

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -404,7 +404,9 @@ def ts_project(
             name = transitive_typecheck_target_name,
             srcs = [name],
             output_group = "transitive_typecheck",
-            **common_kwargs
+            tags = ["manual"] + common_kwargs.get("tags", []),
+            visibility = common_kwargs.get("visibility"),
+            testonly = common_kwargs.get("testonly"),
         )
 
         # Ensures the typecheck target gets built under `bazel test --build_tests_only`
@@ -419,7 +421,7 @@ def ts_project(
         build_test(
             name = transitive_typecheck_test_target_name,
             targets = [transitive_typecheck_target_name],
-            tags = common_kwargs.get("tags"),
+            tags = ["manual"] + common_kwargs.get("tags", []),
             size = "small",
             visibility = common_kwargs.get("visibility"),
         )

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -29,6 +29,14 @@ def _gather_types_from_js_infos(targets):
     ])
     return depset([], transitive = files_depsets)
 
+def _gather_transitive_typecheck_from_output_group_infos(typecheck_outs, targets):
+    files_depsets = [
+        target[OutputGroupInfo].transitive_typecheck
+        for target in targets
+        if OutputGroupInfo in target and "transitive_typecheck" in target[OutputGroupInfo]
+    ]
+    return depset(typecheck_outs, transitive = files_depsets)
+
 def _ts_project_impl(ctx):
     """Creates the action which spawns `tsc`.
 
@@ -308,6 +316,8 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
 
     transitive_types = js_lib_helpers.gather_transitive_types(output_types, srcs_tsconfig_deps)
 
+    transitive_typecheck = _gather_transitive_typecheck_from_output_group_infos(typecheck_outs, ctx.attr.deps)
+
     npm_sources = js_lib_helpers.gather_npm_sources(
         srcs = ctx.attr.srcs + [ctx.attr.tsconfig],
         deps = ctx.attr.deps,
@@ -345,6 +355,7 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
         OutputGroupInfo(
             types = output_types_depset,
             typecheck = depset(typecheck_outs),
+            transitive_typecheck = transitive_typecheck,
             # make the inputs to the tsc action available for analysis testing
             _action_inputs = transitive_inputs_depset,
             # https://bazel.build/extending/rules#validations_output_group


### PR DESCRIPTION
### Changes are visible to end-users: yes/no

With isolated declarations in TypeScript, it's no longer necessarily the case that typechecking a project also causes all of its dependencies to be typechecked. Some people prefer/expect the previous behavior when running typechecking locally, so this PR exposes a test target that will always typecheck a project and its dependencies, regardless whether any of them have enabled the `isolated_typecheck` flag.

### Test plan

Works well in our codebase!
