### PR TITLE
fix: do not declare _typecheck[_test] target when using tsc as transpiler

### DIFF
--- a/examples/transpiler/BUILD.bazel
+++ b/examples/transpiler/BUILD.bazel
@@ -84,7 +84,7 @@ build_test(
     targets = [
         # babel ts_project
         ":babel",
-        ":babel_typecheck",
+        ":babel_types",
         # babel outputted js
         "big.js",  # NOTE: does not implement out_dir in this test
         # tsc outputted dts
@@ -119,6 +119,36 @@ build_test(
         ":typecheck_fail",
         "typecheck_fail.js",
         "typecheck_fail.js.map",
+    ],
+)
+
+# custom js & dts transpilers, tsc will not run for typechecking when only requesting transpiled files.
+# Tagging as manual should prevent the typecheck from running even when requesting
+# transpiler output files.
+ts_project(
+    name = "typecheck_fail-custom_transpilers",
+    srcs = ["typecheck_fail.ts"],
+    declaration = True,
+    declaration_transpiler = partial.make(
+        tsc_dts,
+        args = ["--noCheck"],
+        out_dir = "build-typecheck_fail-custom_transpilers",
+    ),
+    out_dir = "build-typecheck_fail-custom_transpilers",
+    source_map = True,
+    tags = ["manual"],
+    transpiler = partial.make(
+        tsc_js,
+        args = ["--noCheck"],
+        out_dir = "build-typecheck_fail-custom_transpilers",
+    ),
+)
+
+build_test(
+    name = "typecheck_fail-custom_transpilers_test",
+    targets = [
+        ":typecheck_fail-custom_transpilers",
+        ":typecheck_fail-custom_transpilers_types",
     ],
 )
 
@@ -214,7 +244,6 @@ build_test(
     targets = [
         ":custom_dts_transpiler",
         ":custom_dts_transpiler_types",
-        ":custom_dts_transpiler_typecheck",
         "build-custom_dts_transpiler/a.js",
         "build-custom_dts_transpiler/a.d.ts",
     ],
@@ -243,7 +272,6 @@ build_test(
     name = "custom_dts_transpiler-no_declarations-test",
     targets = [
         ":custom_dts_transpiler-no_declarations",
-        ":custom_dts_transpiler-no_declarations_typecheck",
         "build-custom_dts_transpiler-no_declarations/a.js",
     ],
 )

--- a/examples/transpiler/tsc.bzl
+++ b/examples/transpiler/tsc.bzl
@@ -8,7 +8,7 @@ def tsc_dts(name, srcs, out_dir, **kwargs):
         name = name,
         srcs = srcs + ["tsconfig.json"],
         outs = ["%s/%s" % (out_dir, src.replace(".ts", ".d.ts")) for src in srcs],
-        args = [
+        args = kwargs.pop("args", []) + [
             "-p %s/tsconfig.json" % native.package_name(),
             "--emitDeclarationOnly",
             "--outDir %s/%s" % (native.package_name(), out_dir),
@@ -22,7 +22,7 @@ def tsc_js(name, srcs, out_dir, **kwargs):
         name = name,
         srcs = srcs + ["tsconfig.json"],
         outs = ["%s/%s" % (out_dir, src.replace(".ts", ".js")) for src in srcs],
-        args = [
+        args = kwargs.pop("args", []) + [
             "-p %s/tsconfig.json" % native.package_name(),
             "--declaration",
             "false",

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -385,7 +385,7 @@ def ts_project(
             )
 
     # If the primary target does not output dts files then type-checking has a separate target.
-    if not emit_tsc_js or not emit_tsc_dts:
+    if not emit_tsc_js and not emit_tsc_dts:
         typecheck_target_name = "%s_typecheck" % name
         test_target_name = "%s_typecheck_test" % name
 


### PR DESCRIPTION
Declaring the `_typecheck[_test]` targets is only required when tsc is not doing the typechecking while transpiling something.

We did add the `_types` target 100% of the time, transpiler(s) or not. I think we should keep that target 100% of the time. But when should the `_typecheck[_test]` targets be added? This reverts back to be more like before https://github.com/aspect-build/rules_ts/pull/705 where they only exist if tsc will not do type-checking in a different action.

Fix #719

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
