### PR TITLE
Revert "refactor: only pass --outDir flag when needed"

### DIFF
--- a/e2e/external_dep/tsconfig.json
+++ b/e2e/external_dep/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "composite": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/e2e/worker/composite/tsconfig.json
+++ b/e2e/worker/composite/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "composite": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/e2e/worker/feature/tsconfig.json
+++ b/e2e/worker/feature/tsconfig.json
@@ -4,5 +4,7 @@
         "module": "ES2020",
         "moduleResolution": "node",
         "lib": ["ES2015"]
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/e2e/worker/tsconfig.json
+++ b/e2e/worker/tsconfig.json
@@ -3,5 +3,7 @@
         "module": "ES2020",
         "moduleResolution": "node",
         "lib": ["ES2015", "DOM"]
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/connect_node/tsconfig.json
+++ b/examples/connect_node/tsconfig.json
@@ -5,5 +5,7 @@
         "module": "ES2020",
         // TODO: enable lib check here: repair broken type-check
         "skipLibCheck": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/custom_compiler/tsconfig.json
+++ b/examples/custom_compiler/tsconfig.json
@@ -5,5 +5,7 @@
         "lib": ["ES2015", "DOM"],
         "composite": false,
         "experimentalDecorators": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/deps_pkg/tsconfig.json
+++ b/examples/deps_pkg/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/deps_pkg_transpiler/tsconfig.json
+++ b/examples/deps_pkg_transpiler/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/dts_pkg/tsconfig.json
+++ b/examples/dts_pkg/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/emit_declaration_only/tsconfig.json
+++ b/examples/emit_declaration_only/tsconfig.json
@@ -2,5 +2,7 @@
     "compilerOptions": {
         "declaration": true,
         "emitDeclarationOnly": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/extends_chain/tsconfig.json
+++ b/examples/extends_chain/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitAny": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/isolated_declarations/tsconfig.json
+++ b/examples/isolated_declarations/tsconfig.json
@@ -2,5 +2,7 @@
     "compilerOptions": {
         "isolatedDeclarations": true,
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/isolated_typecheck/tsconfig.json
+++ b/examples/isolated_typecheck/tsconfig.json
@@ -2,5 +2,7 @@
     "compilerOptions": {
         "isolatedDeclarations": true,
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/lib_nocompile/tsconfig.json
+++ b/examples/lib_nocompile/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/lib_nocompile_linked/tsconfig.json
+++ b/examples/lib_nocompile_linked/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/linked_empty_node_modules/tsconfig.json
+++ b/examples/linked_empty_node_modules/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/linked_lib/tsconfig.json
+++ b/examples/linked_lib/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/linked_pkg/tsconfig.json
+++ b/examples/linked_pkg/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/linked_tsconfig_consumer/tsconfig.json
+++ b/examples/linked_tsconfig_consumer/tsconfig.json
@@ -1,4 +1,6 @@
 {
     "//": "the hacky path below is required because while @lib/tsconfig/tsconfig.json _will_ resolve, tsc won't follow the symlink into the virtual store so the transitive npm dep of @lib/tsconfig on @tsconfig/node18/tsconfig.json won't be resolvable",
-    "extends": "../node_modules/.aspect_rules_js/@lib+tsconfig@0.0.0/node_modules/@lib/tsconfig/tsconfig.json"
+    "extends": "../node_modules/.aspect_rules_js/@lib+tsconfig@0.0.0/node_modules/@lib/tsconfig/tsconfig.json",
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/no_emit/tsconfig.json
+++ b/examples/no_emit/tsconfig.json
@@ -1,4 +1,6 @@
 {
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": [],
     "compilerOptions": {
         "noEmit": true
     }

--- a/examples/output_group/tsconfig.json
+++ b/examples/output_group/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/path_mappings/tsconfig.json
+++ b/examples/path_mappings/tsconfig.json
@@ -6,5 +6,7 @@
         "paths": {
             "@myorg/*": ["../*"]
         }
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/project_references/lib_a/tsconfig.json
+++ b/examples/project_references/lib_a/tsconfig.json
@@ -2,5 +2,7 @@
     "extends": "./tsconfig-extended.json",
     "compilerOptions": {
         "sourceMap": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/project_references/tsconfig-base.json
+++ b/examples/project_references/tsconfig-base.json
@@ -6,5 +6,7 @@
         "module": "commonjs",
         "target": "ES2015",
         "composite": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/proto_grpc/tsconfig.json
+++ b/examples/proto_grpc/tsconfig.json
@@ -3,5 +3,7 @@
         "module": "ES2022",
         "moduleResolution": "node",
         "lib": ["ES2022", "dom"]
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/resolve_json_module/tsconfig.json
+++ b/examples/resolve_json_module/tsconfig.json
@@ -2,5 +2,7 @@
     "compilerOptions": {
         "esModuleInterop": true,
         "resolveJsonModule": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/resolve_json_module_esm/tsconfig.json
+++ b/examples/resolve_json_module_esm/tsconfig.json
@@ -4,5 +4,7 @@
         "module": "esnext",
         "moduleResolution": "node",
         "resolveJsonModule": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/root_dir/tsconfig.json
+++ b/examples/root_dir/tsconfig.json
@@ -1,1 +1,4 @@
-{}
+{
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
+}

--- a/examples/simple/tsconfig.json
+++ b/examples/simple/tsconfig.json
@@ -9,5 +9,7 @@
             "@myorg/*": ["../*"]
         },
         "types": ["node"]
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/ts_project_dep/a/tsconfig.json
+++ b/examples/ts_project_dep/a/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/ts_project_dep/b/tsconfig.json
+++ b/examples/ts_project_dep/b/tsconfig.json
@@ -1,1 +1,4 @@
-{}
+{
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
+}

--- a/examples/tsbuildinfo/tsconfig.json
+++ b/examples/tsbuildinfo/tsconfig.json
@@ -2,5 +2,7 @@
     "compilerOptions": {
         "composite": true,
         "tsBuildInfoFile": "my.tsbuildinfo"
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/tsconfig_external/tsconfig.json
+++ b/examples/tsconfig_external/tsconfig.json
@@ -1,3 +1,5 @@
 {
-    "extends": "@tsconfig/strictest/tsconfig.json"
+    "extends": "@tsconfig/strictest/tsconfig.json",
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/examples/tsconfig_types/tsconfig.json
+++ b/examples/tsconfig_types/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
         "types": ["node", "./types/typings"]
-    }
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/59036
+    "exclude": []
 }

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -125,28 +125,23 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
     # Add user specified arguments *before* rule supplied arguments
     common_args.extend(ctx.attr.args)
 
-    if (ctx.attr.out_dir and ctx.attr.out_dir != ".") or ctx.attr.root_dir:
-        # TODO: add validation that excludes is non-empty in this case, as passing the --outDir or --declarationDir flag
-        # to TypeScript causes it to set a default for excludes such that it won't find our sources that were copied-to-bin.
-        # See https://github.com/microsoft/TypeScript/issues/59036 and https://github.com/aspect-build/rules_ts/issues/644
-        common_args.extend([
-            "--outDir",
-            _lib.join(ctx.label.workspace_root, ctx.label.package, ctx.attr.out_dir),
-        ])
-
-        if len(typings_outs) > 0:
-            common_args.extend([
-                "--declarationDir",
-                _lib.join(ctx.label.workspace_root, ctx.label.package, typings_out_dir),
-            ])
-
+    outdir = _lib.join(
+        ctx.label.workspace_root,
+        _lib.join(ctx.label.package, ctx.attr.out_dir) if ctx.attr.out_dir else ctx.label.package,
+    )
     tsconfig_path = to_output_relative_path(tsconfig)
     common_args.extend([
         "--project",
         tsconfig_path,
+        "--outDir",
+        outdir,
         "--rootDir",
         _lib.calculate_root_dir(ctx),
     ])
+
+    if len(typings_outs) > 0:
+        declaration_dir = _lib.join(ctx.label.workspace_root, ctx.label.package, typings_out_dir)
+        common_args.extend(["--declarationDir", declaration_dir])
 
     inputs = srcs_inputs + tsconfig_inputs
 


### PR DESCRIPTION
Reverts aspect-build/rules_ts#720

Seeing this failure in Aspect's monorepo after upgrade:

```
Action details (uncached result): http://localhost:7984/blobs/sha256/historical_execute_response/04ad170125e75a56633cd628f1782dbc11b6a2a9a4171f89593d27f6b6d3625f-1170/
/build/root/b098cf6924e0b469/root/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/liquidjs@10.9.2/node_modules/liquidjs/dist/liquid.node.cjs.js:2310
        const taskOrTpl = sync ? yield task : toPromise(task);
                                 ^
 
Error: ENOENT: Failed to lookup "/build/root/b098cf6924e0b469/root/bazel-out/k8-fastbuild/bin/workflows/marvin/domain/templates/comment.liquid" in "."
    at Loader.lookupError (/build/root/b098cf6924e0b469/root/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/liquidjs@10.9.2/node_modules/liquidjs/dist/liquid.node.cjs.js:2252:21)
    at Loader.lookup (/build/root/b098cf6924e0b469/root/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/liquidjs@10.9.2/node_modules/liquidjs/dist/liquid.node.cjs.js:2220:20)
    at lookup.next (<anonymous>)
```

needs a repro here before we try to roll-forward