### PR TITLE
Ensuring package_prefix is correct for external workspaces

### DIFF
--- a/e2e/external_dep/.bazelignore
+++ b/e2e/external_dep/.bazelignore
@@ -1,2 +1,3 @@
 app/
 node_modules/
+sub_external/

--- a/e2e/external_dep/BUILD
+++ b/e2e/external_dep/BUILD
@@ -38,3 +38,28 @@ build_test(
         "lib.ts56rc",
     ],
 )
+
+ts_project(
+    name = "external-deps",
+    srcs = ["lib.ts"],
+    composite = True,
+    out_dir = "external-deps",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@sub_external//:lib1",
+        "@sub_external//:tsconfig-dict",
+        "@sub_external//subdir:lib1",
+        "@sub_external//subdir:tsconfig-dict",
+    ],
+)
+
+build_test(
+    name = "test-external",
+    targets = [
+        ":external-deps",
+        "@sub_external//:lib1",
+        "@sub_external//:tsconfig-dict",
+        "@sub_external//subdir:lib1",
+        "@sub_external//subdir:tsconfig-dict",
+    ],
+)

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -36,3 +36,9 @@ rules_ts_ext.deps(
     ts_version = "5.6.1-rc",
 )
 use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript3")
+
+bazel_dep(name = "sub_external", version = "0.0.0", dev_dependency = True)
+local_path_override(
+    module_name = "sub_external",
+    path = "./sub_external",
+)

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -48,3 +48,8 @@ npm_translate_lock(
 load("@npm//:repositories.bzl", "npm_repositories")
 
 npm_repositories()
+
+local_repository(
+    name = "sub_external",
+    path = "./sub_external",
+)

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -28,6 +28,12 @@ rules_ts_dependencies(
     ts_version = "5.6.1-rc",
 )
 
+# NOTE: only required on non-bzlmod where the sub_external/WORKSPACE is not loaded to declare npm_typescript2
+rules_ts_dependencies(
+    name = "npm_typescript2",
+    ts_version = LATEST_TYPESCRIPT_VERSION,
+)
+
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 
 rules_js_dependencies()

--- a/e2e/external_dep/sub_external/.bazelrc
+++ b/e2e/external_dep/sub_external/.bazelrc
@@ -1,0 +1,18 @@
+# Import Aspect bazelrc presets
+try-import %workspace%/../../../.aspect/bazelrc/bazel7.bazelrc
+import %workspace%/../../../.aspect/bazelrc/convenience.bazelrc
+import %workspace%/../../../.aspect/bazelrc/correctness.bazelrc
+import %workspace%/../../../.aspect/bazelrc/debug.bazelrc
+import %workspace%/../../../.aspect/bazelrc/javascript.bazelrc
+import %workspace%/../../../.aspect/bazelrc/performance.bazelrc
+
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+
+common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
+common --@aspect_rules_ts//ts:default_to_tsc_transpiler
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/../../../.aspect/bazelrc/user.bazelrc

--- a/e2e/external_dep/sub_external/BUILD.bazel
+++ b/e2e/external_dep/sub_external/BUILD.bazel
@@ -2,6 +2,8 @@
 
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
+# NOTE using an alternate npm_typescript name to workaround https://github.com/aspect-build/rules_ts/issues/483
+
 ts_project(
     name = "lib1",
     srcs = ["sub-lib.ts"],

--- a/e2e/external_dep/sub_external/BUILD.bazel
+++ b/e2e/external_dep/sub_external/BUILD.bazel
@@ -1,31 +1,23 @@
 """Tests a `ts_project()` in one workspace being used in another."""
 
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-
-# NOTE using an alternate npm_typescript name to workaround https://github.com/aspect-build/rules_ts/issues/483
+load("//:ts.bzl", "ts_project")
 
 ts_project(
     name = "lib1",
     srcs = ["sub-lib.ts"],
     declaration = True,
     out_dir = "out1",
-    tsc = "@npm_typescript2//:tsc",
-    tsc_worker = "@npm_typescript2//:tsc_worker",
-    validator = "@npm_typescript2//:validator",
     visibility = ["//visibility:public"],
 )
 
 ts_project(
     name = "tsconfig-dict",
     srcs = ["sub-lib.ts"],
-    tsc = "@npm_typescript2//:tsc",
-    tsc_worker = "@npm_typescript2//:tsc_worker",
     tsconfig = {
         "compilerOptions": {
             "declaration": True,
             "outDir": "tsconfig-dict",
         },
     },
-    validator = "@npm_typescript2//:validator",
     visibility = ["//visibility:public"],
 )

--- a/e2e/external_dep/sub_external/BUILD.bazel
+++ b/e2e/external_dep/sub_external/BUILD.bazel
@@ -1,0 +1,29 @@
+"""Tests a `ts_project()` in one workspace being used in another."""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "lib1",
+    srcs = ["sub-lib.ts"],
+    declaration = True,
+    out_dir = "out1",
+    tsc = "@npm_typescript2//:tsc",
+    tsc_worker = "@npm_typescript2//:tsc_worker",
+    validator = "@npm_typescript2//:validator",
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "tsconfig-dict",
+    srcs = ["sub-lib.ts"],
+    tsc = "@npm_typescript2//:tsc",
+    tsc_worker = "@npm_typescript2//:tsc_worker",
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "outDir": "tsconfig-dict",
+        },
+    },
+    validator = "@npm_typescript2//:validator",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/external_dep/sub_external/MODULE.bazel
+++ b/e2e/external_dep/sub_external/MODULE.bazel
@@ -10,6 +10,8 @@ local_path_override(
 )
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
+
+# Use an alternate npm_typescript name to workaround https://github.com/aspect-build/rules_ts/issues/483
 rules_ts_ext.deps(
     name = "npm_typescript2",
 )

--- a/e2e/external_dep/sub_external/MODULE.bazel
+++ b/e2e/external_dep/sub_external/MODULE.bazel
@@ -1,0 +1,16 @@
+module(
+    name = "sub_external",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "aspect_rules_ts", version = "0.0.0")
+local_path_override(
+    module_name = "aspect_rules_ts",
+    path = "../../..",
+)
+
+rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
+rules_ts_ext.deps(
+    name = "npm_typescript2",
+)
+use_repo(rules_ts_ext, "npm_typescript2")

--- a/e2e/external_dep/sub_external/WORKSPACE
+++ b/e2e/external_dep/sub_external/WORKSPACE
@@ -1,0 +1,13 @@
+local_repository(
+    name = "aspect_rules_ts",
+    path = "../../..",
+)
+
+load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")
+
+rules_ts_dependencies(ts_version = LATEST_TYPESCRIPT_VERSION)
+
+rules_ts_dependencies(
+    name = "npm_typescript2",
+    ts_version = "latest",
+)

--- a/e2e/external_dep/sub_external/WORKSPACE
+++ b/e2e/external_dep/sub_external/WORKSPACE
@@ -5,9 +5,7 @@ local_repository(
 
 load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")
 
-rules_ts_dependencies(ts_version = LATEST_TYPESCRIPT_VERSION)
-
 rules_ts_dependencies(
     name = "npm_typescript2",
-    ts_version = "latest",
+    ts_version = LATEST_TYPESCRIPT_VERSION,
 )

--- a/e2e/external_dep/sub_external/sub-lib.ts
+++ b/e2e/external_dep/sub_external/sub-lib.ts
@@ -1,0 +1,1 @@
+console.log("Hello");

--- a/e2e/external_dep/sub_external/subdir/BUILD.bazel
+++ b/e2e/external_dep/sub_external/subdir/BUILD.bazel
@@ -2,6 +2,8 @@
 
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 
+# NOTE using an alternate npm_typescript name to workaround https://github.com/aspect-build/rules_ts/issues/483
+
 ts_project(
     name = "lib1",
     srcs = ["sub-lib.ts"],

--- a/e2e/external_dep/sub_external/subdir/BUILD.bazel
+++ b/e2e/external_dep/sub_external/subdir/BUILD.bazel
@@ -1,31 +1,23 @@
 """Tests a `ts_project()` in one workspace being used in another."""
 
-load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
-
-# NOTE using an alternate npm_typescript name to workaround https://github.com/aspect-build/rules_ts/issues/483
+load("//:ts.bzl", "ts_project")
 
 ts_project(
     name = "lib1",
     srcs = ["sub-lib.ts"],
     declaration = True,
     out_dir = "out1",
-    tsc = "@npm_typescript2//:tsc",
-    tsc_worker = "@npm_typescript2//:tsc_worker",
-    validator = "@npm_typescript2//:validator",
     visibility = ["//visibility:public"],
 )
 
 ts_project(
     name = "tsconfig-dict",
     srcs = ["sub-lib.ts"],
-    tsc = "@npm_typescript2//:tsc",
-    tsc_worker = "@npm_typescript2//:tsc_worker",
     tsconfig = {
         "compilerOptions": {
             "declaration": True,
             "outDir": "tsconfig-dict",
         },
     },
-    validator = "@npm_typescript2//:validator",
     visibility = ["//visibility:public"],
 )

--- a/e2e/external_dep/sub_external/subdir/BUILD.bazel
+++ b/e2e/external_dep/sub_external/subdir/BUILD.bazel
@@ -1,0 +1,29 @@
+"""Tests a `ts_project()` in one workspace being used in another."""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "lib1",
+    srcs = ["sub-lib.ts"],
+    declaration = True,
+    out_dir = "out1",
+    tsc = "@npm_typescript2//:tsc",
+    tsc_worker = "@npm_typescript2//:tsc_worker",
+    validator = "@npm_typescript2//:validator",
+    visibility = ["//visibility:public"],
+)
+
+ts_project(
+    name = "tsconfig-dict",
+    srcs = ["sub-lib.ts"],
+    tsc = "@npm_typescript2//:tsc",
+    tsc_worker = "@npm_typescript2//:tsc_worker",
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "outDir": "tsconfig-dict",
+        },
+    },
+    validator = "@npm_typescript2//:validator",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/external_dep/sub_external/subdir/sub-lib.ts
+++ b/e2e/external_dep/sub_external/subdir/sub-lib.ts
@@ -1,0 +1,1 @@
+console.log("Hello");

--- a/e2e/external_dep/sub_external/subdir/tsconfig.json
+++ b/e2e/external_dep/sub_external/subdir/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "outDir": "out1",
+        "declaration": true
+    }
+}

--- a/e2e/external_dep/sub_external/ts.bzl
+++ b/e2e/external_dep/sub_external/ts.bzl
@@ -1,0 +1,14 @@
+"""
+Util for hiding ts_project() workaround for  https://github.com/aspect-build/rules_ts/issues/483
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", _ts_project = "ts_project")
+
+def ts_project(name, **kwargs):
+    _ts_project(
+        name = name,
+        tsc = "@npm_typescript2//:tsc",
+        tsc_worker = "@npm_typescript2//:tsc_worker",
+        validator = "@npm_typescript2//:validator",
+        **kwargs
+    )

--- a/e2e/external_dep/sub_external/tsconfig.json
+++ b/e2e/external_dep/sub_external/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "outDir": "out1",
+        "declaration": true
+    }
+}

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -140,6 +140,11 @@ def _write_tsconfig_rule(ctx):
     # Update file paths to be relative to the tsconfig file, including a ./ prefix
     # to ensure paths are all relative to the config file.
     package_prefix = ctx.label.package + "/"
+
+    # If the target is inside another workspace, we will need to also add the workspace
+    # root to the prefix.
+    if (len(ctx.label.repo_name) > 0):
+        package_prefix = "../{}/{}".format(ctx.label.repo_name, package_prefix)
     filtered_files = [
         "./" + f.short_path.removeprefix(package_prefix)
         for f in filtered_files


### PR DESCRIPTION
This is a fix over the changes in https://github.com/aspect-build/rules_ts/pull/687.

### Test plan
New unit-tests

- Covered by existing test cases: partial
- New test cases added: added under `e2e` folder.
- Manual testing; please provide instructions so we can reproduce:
  - Add a TS repo as an external repository. This should have a target that:
    - is a `ts_project`
    - inside a subfolder
    - has `tsconfig` attribute set to a `dict`.
  - build the `ts_project` target inside this external repository
