### PR TITLE
fix: support setting resolveJsonModule with inline ts_project(tsconfig)

### DIFF
--- a/examples/json_data/BUILD.bazel
+++ b/examples/json_data/BUILD.bazel
@@ -16,7 +16,6 @@ ts_project(
         "src/tsdata.txt",
         ":fg",
     ],
-    resolve_json_module = True,
     tsconfig = {
         "compilerOptions": {
             "resolveJsonModule": True,

--- a/examples/resolve_json_module/BUILD.bazel
+++ b/examples/resolve_json_module/BUILD.bazel
@@ -13,6 +13,36 @@ ts_project(
     resolve_json_module = True,
 )
 
+ts_project(
+    name = "ts-dict-override",
+    srcs = [
+        "data.json",
+        "index.ts",
+    ],
+    extends = "tsconfig.json",
+    tsconfig = {
+        "compilerOptions": {
+            "outDir": "ts-dict-override",
+            "resolveJsonModule": True,
+        },
+    },
+)
+
+ts_project(
+    name = "ts-dict-unspecified",
+    srcs = [
+        "data.json",
+        "index.ts",
+    ],
+    extends = "tsconfig.json",
+    resolve_json_module = True,
+    tsconfig = {
+        "compilerOptions": {
+            "outDir": "ts-dict-unspecified",
+        },
+    },
+)
+
 assert_contains(
     name = "test",
     actual = "index.js",
@@ -25,3 +55,17 @@ js_test(
     data = [":ts"],
     entry_point = "index.js",
 )
+
+# Test that the json is available at runtime with various ways of
+# specifying resolveJsonModule in tsconfig.json.
+[
+    js_test(
+        name = "ts-with-json-%s" % t,
+        data = [":ts-%s" % t],
+        entry_point = "ts-%s/index.js" % t,
+    )
+    for t in [
+        "dict-override",
+        "dict-unspecified",
+    ]
+]


### PR DESCRIPTION
I noticed `resolveJsonModule` is treated different then all the other tsconfig attributes which must be aligned between the macro and tsconfig where you can't depend on the tsconfig dict. This allows setting the value only in the tsconfig dict like any other compiler option.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
