### PR TITLE
fix: support --incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,8 +11,8 @@ import %workspace%/.aspect/bazelrc/performance.bazelrc
 common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
-# We have some empty globs in this repo
-common --noincompatible_disallow_empty_glob
+# opt-in to flag that is on by default in Bazel 8
+common --incompatible_disallow_empty_glob
 
 # Never Compile protoc Again
 common --incompatible_enable_proto_toolchain_resolution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,7 +27,7 @@ bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
-bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "toolchains_protoc", version = "0.3.0", dev_dependency = True)
 
 # Should not be required, stardoc leaks a dependency
@@ -36,13 +36,6 @@ bazel_dep(name = "rules_java", version = "7.6.1", dev_dependency = True)
 register_toolchains(
     "//tools/toolchains:all",
     dev_dependency = True,
-)
-
-# pick up fix: https://github.com/bazelbuild/stardoc/pull/221
-git_override(
-    module_name = "stardoc",
-    commit = "3baa5d1761970c6285d2ac9c3adccfaac42f54c5",
-    remote = "https://github.com/bazelbuild/stardoc.git",
 )
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -47,6 +47,8 @@ Future work
 ## ts_proto_library
 
 <pre>
+load("@aspect_rules_ts//ts:proto.bzl", "ts_proto_library")
+
 ts_proto_library(<a href="#ts_proto_library-name">name</a>, <a href="#ts_proto_library-node_modules">node_modules</a>, <a href="#ts_proto_library-proto">proto</a>, <a href="#ts_proto_library-protoc_gen_options">protoc_gen_options</a>, <a href="#ts_proto_library-gen_connect_es">gen_connect_es</a>, <a href="#ts_proto_library-gen_connect_query">gen_connect_query</a>,
                  <a href="#ts_proto_library-gen_connect_query_service_mapping">gen_connect_query_service_mapping</a>, <a href="#ts_proto_library-copy_files">copy_files</a>, <a href="#ts_proto_library-proto_srcs">proto_srcs</a>, <a href="#ts_proto_library-files_to_copy">files_to_copy</a>, <a href="#ts_proto_library-kwargs">kwargs</a>)
 </pre>

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -10,6 +10,8 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 ## rules_ts_dependencies
 
 <pre>
+load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
+
 rules_ts_dependencies(<a href="#rules_ts_dependencies-name">name</a>, <a href="#rules_ts_dependencies-ts_version_from">ts_version_from</a>, <a href="#rules_ts_dependencies-ts_version">ts_version</a>, <a href="#rules_ts_dependencies-ts_integrity">ts_integrity</a>)
 </pre>
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -10,6 +10,8 @@ inputs and produces JavaScript or declaration (.d.ts) outputs.
 ## ts_config
 
 <pre>
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+
 ts_config(<a href="#ts_config-name">name</a>, <a href="#ts_config-deps">deps</a>, <a href="#ts_config-src">src</a>)
 </pre>
 
@@ -35,6 +37,8 @@ extended configuration file as well, to pass them both to the TypeScript compile
 ## ts_project_rule
 
 <pre>
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project_rule")
+
 ts_project_rule(<a href="#ts_project_rule-name">name</a>, <a href="#ts_project_rule-deps">deps</a>, <a href="#ts_project_rule-srcs">srcs</a>, <a href="#ts_project_rule-data">data</a>, <a href="#ts_project_rule-allow_js">allow_js</a>, <a href="#ts_project_rule-args">args</a>, <a href="#ts_project_rule-assets">assets</a>, <a href="#ts_project_rule-buildinfo_out">buildinfo_out</a>, <a href="#ts_project_rule-composite">composite</a>,
                 <a href="#ts_project_rule-declaration">declaration</a>, <a href="#ts_project_rule-declaration_dir">declaration_dir</a>, <a href="#ts_project_rule-declaration_map">declaration_map</a>, <a href="#ts_project_rule-declaration_transpile">declaration_transpile</a>,
                 <a href="#ts_project_rule-emit_declaration_only">emit_declaration_only</a>, <a href="#ts_project_rule-extends">extends</a>, <a href="#ts_project_rule-incremental">incremental</a>, <a href="#ts_project_rule-is_typescript_5_or_greater">is_typescript_5_or_greater</a>,
@@ -101,6 +105,8 @@ for srcs and tsconfig, and pre-declaring output files.
 ## TsConfigInfo
 
 <pre>
+load("@aspect_rules_ts//ts:defs.bzl", "TsConfigInfo")
+
 TsConfigInfo(<a href="#TsConfigInfo-deps">deps</a>)
 </pre>
 
@@ -109,7 +115,6 @@ along with any transitively referenced tsconfig.json files chained by the
 "extends" feature
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -121,6 +126,8 @@ along with any transitively referenced tsconfig.json files chained by the
 ## ts_project
 
 <pre>
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
 ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">tsconfig</a>, <a href="#ts_project-srcs">srcs</a>, <a href="#ts_project-args">args</a>, <a href="#ts_project-data">data</a>, <a href="#ts_project-deps">deps</a>, <a href="#ts_project-assets">assets</a>, <a href="#ts_project-extends">extends</a>, <a href="#ts_project-allow_js">allow_js</a>, <a href="#ts_project-isolated_typecheck">isolated_typecheck</a>,
            <a href="#ts_project-declaration">declaration</a>, <a href="#ts_project-source_map">source_map</a>, <a href="#ts_project-declaration_map">declaration_map</a>, <a href="#ts_project-resolve_json_module">resolve_json_module</a>, <a href="#ts_project-preserve_jsx">preserve_jsx</a>, <a href="#ts_project-composite">composite</a>,
            <a href="#ts_project-incremental">incremental</a>, <a href="#ts_project-no_emit">no_emit</a>, <a href="#ts_project-emit_declaration_only">emit_declaration_only</a>, <a href="#ts_project-transpiler">transpiler</a>, <a href="#ts_project-declaration_transpiler">declaration_transpiler</a>,

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -33,8 +33,11 @@ def rules_ts_internal_deps():
 
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
-        urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
+        sha256 = "fabb280f6c92a3b55eed89a918ca91e39fb733373c81e87a18ae9e32e75023ec",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
+            "https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
+        ],
     )
 
     http_archive(

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -49,9 +49,9 @@ def rules_ts_internal_deps():
 
     http_archive(
         name = "rules_proto",
-        sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
-        strip_prefix = "rules_proto-6.0.0",
-        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
+        sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
+        strip_prefix = "rules_proto-6.0.2",
+        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
     )
 
     http_archive(

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -33,7 +33,7 @@ def rules_ts_internal_deps():
 
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "fabb280f6c92a3b55eed89a918ca91e39fb733373c81e87a18ae9e32e75023ec",
+        sha256 = "fabb280f6c92a3b55eed89a918ca91e39fb733373c81e87a18ae9e33e75023ec",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
             "https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -23,7 +23,7 @@ def _is_file_missing(label):
     """
     file_abs = "%s/%s" % (label.package, label.name)
     file_rel = file_abs[len(native.package_name()) + 1:]
-    file_glob = native.glob([file_rel])
+    file_glob = native.glob([file_rel], allow_empty = True)
     return len(file_glob) == 0
 
 _tsc = "@npm_typescript//:tsc"

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -475,7 +475,7 @@ def _default_srcs(allow_js, resolve_json_module):
         include.append("**/*.json")
         exclude.extend(["**/package.json", "**/package-lock.json", "**/tsconfig*.json"])
 
-    return native.glob(include, exclude)
+    return native.glob(include, exclude, allow_empty = True)
 
 def _invoke_custom_transpiler(type_str, transpiler, transpile_target_name, srcs, common_kwargs):
     if type(transpiler) == "function" or type(transpiler) == "rule":


### PR DESCRIPTION
This flag was flipped for Bazel 8. Need this for rules_ts rollout at a client.
