### PR TITLE
docs: change release notes to encourage bzlmod

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -14,7 +14,7 @@ git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip >$ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat <<EOF
-## Using [Bzlmod] with Bazel 6:
+## Using [Bzlmod]:
 
 Add to your \`MODULE.bazel\` file:
 
@@ -32,7 +32,7 @@ use_repo(rules_ts_ext, "npm_typescript")
 
 [Bzlmod]: https://bazel.build/build/bzlmod
 
-## Using WORKSPACE
+## Using legacy WORKSPACE
 
 Paste this snippet into your \`WORKSPACE\` file:
 


### PR DESCRIPTION
The previous wording "with Bazel 6" is outdated and makes that option appear to be the "legacy old bazel 6" snippet.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
