### PR TITLE
ts_project: ensure assets get propagated

### DIFF
--- a/examples/assets/BUILD.bazel
+++ b/examples/assets/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_outputs")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -42,6 +43,34 @@ ts_project(
     extends = ":config",
     out_dir = "out",
     tsconfig = {"compilerOptions": {"outDir": "out"}},
+)
+
+ts_project(
+    name = "ts-runtime-assets",
+    srcs = ["src/index-runtime.ts"],
+    assets = ["src/generated.json"],
+    tsconfig = ":config",
+)
+
+js_test(
+    name = "ts-runtime-assets_test",
+    data = [":ts-runtime-assets"],
+    entry_point = "src/index-runtime.js",
+)
+
+ts_project(
+    name = "ts-runtime-outdir-assets",
+    srcs = ["src/index-runtime.ts"],
+    assets = ["src/generated.json"],
+    extends = ":config",
+    out_dir = "out",
+    tsconfig = {"compilerOptions": {"outDir": "out"}},
+)
+
+js_test(
+    name = "ts-runtime-outdir-assets_test",
+    data = [":ts-runtime-outdir-assets"],
+    entry_point = "out/src/index-runtime.js",
 )
 
 filegroup(

--- a/examples/assets/src/index-runtime.ts
+++ b/examples/assets/src/index-runtime.ts
@@ -1,0 +1,11 @@
+/**
+ * This testcase exists to verify assets get propagated correctly. It
+ * intentionally does not use `import` or `require` for the generated asset to
+ * more closely mimic what a downstream rule (eg. a bundler) would do.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+const data = fs.readFileSync(path.join(__dirname, 'generated.json'))
+
+console.log(__dirname, data)

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -167,6 +167,8 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             asset = ctx.actions.declare_file(a_out)
             copy_file_action(ctx, a, asset)
             assets_outs.append(asset)
+        else:
+            assets_outs.append(a)
 
     outputs = js_outs + map_outs + typings_outs + typing_maps_outs
     if ctx.outputs.buildinfo_out:


### PR DESCRIPTION
https://github.com/aspect-build/rules_ts/pull/533, in fixing the issue caused by https://github.com/aspect-build/rules_ts/pull/493, also omitted adding assets that shouldn't be copied to the `JsInfo` provider. As a result, downstream rules (such as `esbuild`) will fail to find the file because it never collected it.

---

### Changes are visible to end-users: no

### Test plan

- New test cases added
- Manual testing; please provide instructions so we can reproduce:

Easiest way to repro this issue is to pipe the existing test cases into an `esbuild` bundle. The target should fail with `[plugin: bazel-sandbox] Could not resolve "./generated.json"`.
