### PR TITLE
test: demonstrate issue with ts_project(transpiler) and .d.ts srcs

### DIFF
--- a/examples/dts_pkg-outDir/BUILD.bazel
+++ b/examples/dts_pkg-outDir/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_project(
+    name = "lib",
+    srcs = [
+        "index.ts",
+        "lib_types.d.ts",
+        "lib_types_2.d.mts",
+    ],
+    declaration = True,
+    out_dir = "dist",
+    visibility = ["//examples:__subpackages__"],
+)
+
+npm_package(
+    name = "pkg",
+    srcs = [":lib"],
+    package = "@myorg/dts_pkg",
+    visibility = ["//examples:__subpackages__"],
+)
+
+ts_project(
+    name = "importer_linked_ts",
+    srcs = ["importer_linked.ts"],
+    declaration = True,
+    out_dir = "dist",
+    deps = [
+        "//examples:node_modules/@myorg/dts_pkg",
+    ],
+)
+
+build_test(
+    name = "importer_linked_test",
+    targets = [":importer_linked_ts"],
+)

--- a/examples/dts_pkg-outDir/importer_linked.ts
+++ b/examples/dts_pkg-outDir/importer_linked.ts
@@ -1,0 +1,4 @@
+import { A, B } from '@myorg/dts_pkg'
+
+export const a: A = 42
+export const b: B = 'Forty Two'

--- a/examples/dts_pkg-outDir/index.ts
+++ b/examples/dts_pkg-outDir/index.ts
@@ -1,0 +1,2 @@
+export * from './lib_types'
+export * from './lib_types_2.mjs'

--- a/examples/dts_pkg-outDir/lib_types.d.ts
+++ b/examples/dts_pkg-outDir/lib_types.d.ts
@@ -1,0 +1,1 @@
+export type A = number

--- a/examples/dts_pkg-outDir/lib_types_2.d.mts
+++ b/examples/dts_pkg-outDir/lib_types_2.d.mts
@@ -1,0 +1,1 @@
+export type B = string

--- a/examples/dts_pkg-outDir/tsconfig.json
+++ b/examples/dts_pkg-outDir/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "outDir": "dist"
+    }
+}

--- a/examples/transpiler/BUILD.bazel
+++ b/examples/transpiler/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_outputs")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
@@ -27,6 +28,22 @@ write_file(
     out = "a.ts",
     content = [
         "export const b: number = 43",
+    ],
+)
+
+write_file(
+    name = "gen_c_js",
+    out = "c.js",
+    content = [
+        "export const c = 44",
+    ],
+)
+
+write_file(
+    name = "gen_c_dts",
+    out = "c.d.ts",
+    content = [
+        "export const c: number",
     ],
 )
 
@@ -272,5 +289,56 @@ build_test(
         ":custom_dts_transpiler-declarations_only",
         ":custom_dts_transpiler-declarations_only_typecheck",
         "build-custom_dts_transpiler-no_declarations/a.d.ts",
+    ],
+)
+
+ts_project(
+    name = "declarations_tsc",
+    srcs = [
+        "a.ts",
+        "c.d.ts",
+    ],
+    out_dir = "build-declarations_tsc",
+    transpiler = "tsc",
+    tsconfig = {
+        "compilerOptions": {
+            "sourceMap": True,
+        },
+    },
+)
+
+assert_outputs(
+    name = "declarations_tsc_test",
+    actual = ":declarations_tsc",
+    expected = [
+        "examples/transpiler/build-declarations_tsc/a.js",
+        "examples/transpiler/build-declarations_tsc/a.js.map",
+    ],
+)
+
+ts_project(
+    name = "declarations_custom",
+    srcs = [
+        "a.ts",
+        "c.d.ts",
+    ],
+    out_dir = "build-declarations_custom",
+    transpiler = partial.make(
+        babel,
+        out_dir = "build-declarations_custom",
+    ),
+    tsconfig = {
+        "compilerOptions": {
+            "sourceMap": True,
+        },
+    },
+)
+
+assert_outputs(
+    name = "declarations_custom_test",
+    actual = ":declarations_custom",
+    expected = [
+        "examples/transpiler/build-declarations_custom/a.js",
+        "examples/transpiler/build-declarations_custom/a.js.map",
     ],
 )

--- a/examples/transpiler/babel.bzl
+++ b/examples/transpiler/babel.bzl
@@ -38,6 +38,9 @@ def babel(name, srcs, out_dir = None, resolve_json = False, commonjs = False, **
             outs.append(":{}_{}".format(name, idx))
             continue
 
+        if src.endswith(".d.ts") or src.endswith(".d.mts"):
+            continue
+
         if not (src.endswith(".ts") or src.endswith(".mts")):
             fail("babel example transpiler only supports source .[m]ts or .json files, found: %s" % src)
 


### PR DESCRIPTION
A similar change will be required in swc to handle `.d.ts` files, similar to what tsc and the updated babel test are doing.

### Changes are visible to end-users: no

### Test plan

- New test cases added
