### PR TITLE
refactor: simplify tsconfig.json files computation

### DIFF
--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -140,7 +140,7 @@ def _write_tsconfig_rule(ctx):
     src_files = []
     for f in ctx.files.files:
         # Only include typescript source files
-        if not (_lib.is_ts_src(f.basename, ctx.attr.allow_js, ctx.attr.resolve_json_module) or _lib.is_typings_src(f.basename)):
+        if not _lib.is_ts_src(f.basename, ctx.attr.allow_js, ctx.attr.resolve_json_module, True):
             continue
 
         if f.short_path.startswith(local_package_prefix):

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -211,9 +211,9 @@ def _is_js_src(src, allow_js, resolve_json_module):
 
     return False
 
-def _is_ts_src(src, allow_js, resolve_json_module):
-    if (src.endswith(".ts") or src.endswith(".tsx") or src.endswith(".mts") or src.endswith(".cts")):
-        return not _is_typings_src(src)
+def _is_ts_src(src, allow_js, resolve_json_module, include_typings):
+    if src.endswith(".ts") or src.endswith(".tsx") or src.endswith(".mts") or src.endswith(".cts"):
+        return include_typings or not _is_typings_src(src)
 
     return _is_js_src(src, allow_js, resolve_json_module)
 
@@ -228,7 +228,7 @@ def _to_out_path(f, out_dir, root_dir):
 def _to_js_out_paths(srcs, out_dir, root_dir, allow_js, resolve_json_module, ext_map, default_ext):
     outs = []
     for f in srcs:
-        if _is_ts_src(f, allow_js, resolve_json_module):
+        if _is_ts_src(f, allow_js, resolve_json_module, False):
             out = _to_out_path(f, out_dir, root_dir)
             ext_idx = out.rindex(".")
             out = out[:ext_idx] + ext_map.get(out[ext_idx:], default_ext)


### PR DESCRIPTION
I found this confusing, and now this avoids invoking `_is_typings_src` 2x for every single src within the `ts_config` rule.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
