### PR TITLE
fix: do not include `tsconfig.json` files in `JsInfo` types

### DIFF
--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -51,8 +51,7 @@ def _ts_config_impl(ctx):
             transitive_deps.append(dep[TsConfigInfo].deps)
 
     transitive_sources = js_lib_helpers.gather_transitive_sources([], ctx.attr.deps)
-
-    transitive_types = js_lib_helpers.gather_transitive_types(files, ctx.attr.deps)
+    transitive_types = js_lib_helpers.gather_transitive_types([], ctx.attr.deps)
 
     npm_sources = js_lib_helpers.gather_npm_sources(
         srcs = [],


### PR DESCRIPTION
It's unclear to me why the `tsconfig.json` files from `ts_config` targets end up contributing to the JSInfo type declarations. Those files shouldn't be necessary for represent the output of a TS compilation in general.

I assume, they could be necessary for composite projects, but even then I'd expect the tsconfig to be retrieved in consuming targets via the dedicated `TsConfigInfo` provider.

Related: https://github.com/angular/angular-cli/pull/29282