### PR TITLE
test: use specific node version for pnpm in bat-tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,6 +178,12 @@ jobs:
               # then use .bazelversion to determine which Bazel version to use
               run: echo "${{ matrix.bazel-version.version }}" > .bazelversion
 
+            - name: Install Node.js
+              uses: actions/setup-node@v3
+              with:
+                  # pnpm 7 does not work with latest node 20
+                  node-version: 19
+
             - uses: pnpm/action-setup@v2
               with:
                   version: '7.14.2'

--- a/e2e/test/common.bats
+++ b/e2e/test/common.bats
@@ -19,6 +19,7 @@ function workspace() {
 		esac
 	done
 
+	touch MODULE.bazel
 	cat >WORKSPACE <<EOF
 local_repository(
     name = "aspect_rules_ts",


### PR DESCRIPTION
It seems github workflows upgrade node and the pnpm version being used no longer works with the latest node. I had the same problem locally.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
