### PR TITLE
fix: add tsconfig root_dir/exclude validation

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -298,6 +298,13 @@ def ts_project(
         declaration_dir = compiler_options.pop("declarationDir", declaration_dir)
         root_dir = compiler_options.pop("rootDir", root_dir)
 
+        # When generating a tsconfig.json and we set rootDir we need to add the exclude field,
+        # because of these tickets (validation for not generated tsconfig is also present elsewhere):
+        # https://github.com/microsoft/TypeScript/issues/59036 and
+        # 'https://github.com/aspect-build/rules_ts/issues/644
+        if root_dir != None and "exclude" not in tsconfig:
+            tsconfig["exclude"] = []
+
         if srcs == None:
             # Default sources based on macro attributes after applying tsconfig properties
             srcs = _default_srcs(

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -227,6 +227,8 @@ def _to_out_path(f, out_dir, root_dir):
 
 def _to_js_out_paths(srcs, out_dir, root_dir, allow_js, resolve_json_module, ext_map, default_ext):
     outs = []
+    out_dir = _remove_leading_dot_slash(out_dir)
+    root_dir = _remove_leading_dot_slash(root_dir)
     for f in srcs:
         if _is_ts_src(f, allow_js, resolve_json_module, False):
             out = _to_out_path(f, out_dir, root_dir)
@@ -324,6 +326,9 @@ def _declare_outputs(ctx, paths):
         ctx.actions.declare_file(path)
         for path in paths
     ]
+
+def _remove_leading_dot_slash(string_path):
+    return string_path.removeprefix("./") if string_path else string_path
 
 lib = struct(
     declare_outputs = _declare_outputs,

--- a/ts/private/ts_project_options_validator.js
+++ b/ts/private/ts_project_options_validator.js
@@ -113,6 +113,26 @@ function main(_a) {
             )
         }
     }
+    function checkRootDirExclude() {
+        var rootDirAttrValue = attrs["root_dir"];
+        var outDirAttrValue = attrs["out_dir"];
+        var excludeOptionValue = config["exclude"];
+
+        let rootDirNotEmpty = rootDirAttrValue !== undefined && rootDirAttrValue !== "";
+        let outDirEmpty = outDirAttrValue === undefined || outDirAttrValue === "";
+
+        if (rootDirNotEmpty && outDirEmpty && excludeOptionValue === undefined) {
+            throw new Error(
+                '\n\nWhen root dir is set, exclude must also be set to empty array in the tsconfig file.\n\n' +
+                'For example, tsconfig.json:\n' +
+                '{\n' +
+                '   "exclude": []\n' +
+                '}\n\n' +
+                'See tickets: https://github.com/microsoft/TypeScript/issues/59036 and ' +
+                'https://github.com/aspect-build/rules_ts/issues/644\n'
+            )
+        }
+    }
     var jsxEmit =
         ((_b = {}),
         (_b[ts.JsxEmit.None] = 'none'),
@@ -175,6 +195,7 @@ function main(_a) {
     check('incremental')
     check('tsBuildInfoFile', 'ts_build_info_file')
     check_out_dir()
+    checkRootDirExclude()
     check_nocheck()
     check_preserve_jsx()
     if (failures.length > 0) {

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -26,6 +26,7 @@ Assumes all tsconfig file deps are already copied to the bin directory.
         incremental = ctx.attr.incremental,
         ts_build_info_file = ctx.attr.ts_build_info_file,
         isolated_typecheck = ctx.attr.isolated_typecheck,
+        root_dir = ctx.attr.root_dir,
     )
     arguments.add_all([
         to_output_relative_path(tsconfig),

--- a/ts/test/ts_project_test.bzl
+++ b/ts/test/ts_project_test.bzl
@@ -170,12 +170,32 @@ def ts_project_test_suite(name):
         targets = [":wrapper.d.ts.map"],
     )
 
+    write_file(
+        name = "dirty_out_dir_ts",
+        out = "dirty_out_dir.ts",
+        content = ["console.log(1)"],
+        tags = ["manual"],
+    )
+    ts_project_wrapper(
+        name = "dirty_out_dir",
+        srcs = ["dirty_out_dir.ts"],
+        out_dir = "./out-dir",
+        tsconfig = _TSCONFIG,
+        tags = ["manual"],
+    )
+
+    build_test(
+        name = "dirty_out_dir_test",
+        targets = [":dirty_out_dir"],
+    )
+
     native.test_suite(
         name = name,
         tests = [
             ":dir_test",
             ":use_dir_test",
             ":wrapper_test",
+            ":dirty_out_dir_test",
         ],
     )
 


### PR DESCRIPTION
Close #644

--

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: N/A
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: Yes

Normalize `ts_project` `*_dir` attribute paths.

Validate any use of `root_dir` includes the `exclude: []` workaround for https://github.com/aspect-build/rules_ts/issues/644

### Test plan

- New test cases added

Before the change any usage of a declaration_dir that starts with "./" was leading to an error, now if the path starts with "./" it is simply removed and the behavior is as if it was not added at all.

### Before the change:
| declaration_dir | tsconfig declarationDir | Result | Message                                                                                  |
|------------------|-------------------------|--------|------------------------------------------------------------------------------------------|
|                  | undefined              | PASS   |                                                                                          |
| .                | undefined              | PASS   |                                                                                          |
| ./               | undefined              | FAIL   | invalid target name './/foo.d.ts': target names may not contain '.' as a path segment    |
| ./dir            | undefined              | FAIL   | invalid target name './dir/foo.d.ts': target names may not contain '.' as a path segment |
| ./dir            | ./dir                  | FAIL   | invalid target name './dir/foo.d.ts': target names may not contain '.' as a path segment |
| out              | undefined              | FAIL   | not all outputs were created or valid                                                   |
| out              | out                    | PASS   |                                                                                          |
| undefined        | out                    | FAIL   | not all outputs were created or valid                                                   |
| out              | ./out                  | PASS   |                                                                                          |


### After the change:
| declaration_dir | tsconfig declarationDir | Result | Message                              |
|------------------|-------------------------|--------|--------------------------------------|
|                  | undefined              | PASS   |                                      |
| .                | undefined              | PASS   |                                      |
| ./               | undefined              | PASS   |                                      |
| ./dir            | undefined              | FAIL   | not all outputs were created or valid |
| ./dir            | ./dir                  | PASS   |                                      |
| dir              | undefined              | FAIL   | not all outputs were created or valid |
| dir              | dir                    | PASS   |                                      |
| undefined        | dir                    | FAIL   | not all outputs were created or valid |
| dir              | ./dir                  | PASS   |                                      |

