### PR TITLE
fix: ensure ts_project _types target has the right visibility

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -385,6 +385,7 @@ def ts_project(
             native.alias(
                 name = types_target_name,
                 actual = declarations_target_name,
+                visibility = common_kwargs.get("visibility"),
             )
         else:
             # tsc outputs the types and must be extracted via output_group


### PR DESCRIPTION
If this is not passed, the _types target will get the package's default visibility.

In out case, we have a package with a very restrictive visibility, but one of the targets (`ts_project`) in the package is  explicitly set to `public`. We want to depend on the `_types` target, but that is not visible due the default visibility.
NOTE: This is relevant only when an `dts` emitter is provided.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan
- Manual testing; please provide instructions so we can reproduce:
Create a target with a `dts` emitter. Ensure the `_types` target gets the same visibility of the main target.
