### PR TITLE
Ensuring the _types target (when alias) has the right tags

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -386,6 +386,7 @@ def ts_project(
                 name = types_target_name,
                 actual = declarations_target_name,
                 visibility = common_kwargs.get("visibility"),
+                tags = common_kwargs.get("tags", []),
             )
         else:
             # tsc outputs the types and must be extracted via output_group


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->
When using the `alias` variant of the `_types` (dedicated dts_emitter) the target will not be given the provided `tags`, unlike all the other targets generated by this macro, including the `_types` when created using the `filegroup`.

---

### Changes are visible to end-users: yes/no
no

### Test plan
`bazel query //:target_types --output=xml` will show that the `tags` attribute was set correctly.
