### PR TITLE
Disallow remote cache with workers

### DIFF
--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -142,6 +142,8 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
 
     if supports_workers:
         execution_requirements["supports-workers"] = "1"
+        # Workers may not be fully hermetic so we don't want to potentially poison the remote cache.
+        execution_requirements["no-remote-cache-upload"] = "1"
         execution_requirements["worker-key-mnemonic"] = "TsProject"
         executable = ctx.executable.tsc_worker
 

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -142,6 +142,7 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
 
     if supports_workers:
         execution_requirements["supports-workers"] = "1"
+
         # Workers may not be fully hermetic so we don't want to potentially poison the remote cache.
         execution_requirements["no-remote-cache-upload"] = "1"
         execution_requirements["worker-key-mnemonic"] = "TsProject"


### PR DESCRIPTION
This is a patch that we've had at Airtable for a while, but didn't get around to upstreaming until now.

### Changes are visible to end-users: no

Doubt this would be a visible change by most.

### Test plan

- Covered by existing test cases
