### PR TITLE
Add support to `ts_project()` for `assets` that are generated directly into the `outDir`

### DIFF
--- a/examples/assets/BUILD.bazel
+++ b/examples/assets/BUILD.bazel
@@ -164,18 +164,36 @@ ts_project(
     tsconfig = ":config",
 )
 
+genrule(
+    name = "generated_root_output_file",
+    outs = ["root-out/metadata/generated_metadata.json"],
+    cmd = "echo 1 > $@",
+)
+
 ts_project(
     name = "ts-root-out",
     srcs = [
         "src/index.ts",
     ],
     assets = [
+        "root-out/metadata/generated_metadata.json",
         "src/styles.css",
         "src/generated.json",
     ],
     out_dir = "root-out",
     root_dir = "src",
     tsconfig = ":config",
+)
+
+assert_outputs(
+    name = "ts-root-out_outputs_test",
+    actual = ":ts-root-out",
+    expected = [
+        "examples/assets/root-out/generated.json",
+        "examples/assets/root-out/index.js",
+        "examples/assets/root-out/metadata/generated_metadata.json",
+        "examples/assets/root-out/styles.css",
+    ],
 )
 
 build_test(

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -222,9 +222,14 @@ def _is_ts_src(src, allow_js, resolve_json_module, include_typings):
 
 def _to_out_path(f, out_dir, root_dir):
     f = f[f.find(":") + 1:]
+    out_dir = out_dir if out_dir != "." else None
+
+    if out_dir and f.startswith(out_dir + "/"):
+        return f
+
     if root_dir:
         f = f.removeprefix(root_dir + "/")
-    if out_dir and out_dir != ".":
+    if out_dir:
         f = out_dir + "/" + f
     return f
 


### PR DESCRIPTION
Add support to `ts_project()` for `assets` that are generated directly into the `outDir`.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

- Covered by existing test cases
- New test cases added

Before this PR the `ts-root-out_outputs_test` fails because the `outDir` gets duplicated (`root-out/root-out`):

```
==================== Test output for //examples/assets:ts-root-out_outputs_test:
3c3
< examples/assets/root-out/metadata/generated_metadata.json
---
> examples/assets/root-out/root-out/metadata/generated_metadata.json
FAIL: files "examples/assets/_expected_ts-root-out_outputs_test.txt" and "examples/assets/_ts-root-out_outputs_test_outputs.txt" differ.
================================================================================
```