### PR TITLE
fix: isolated_typecheck and transitive tsconfig deps

### DIFF
--- a/examples/extends_chain/main/BUILD.bazel
+++ b/examples/extends_chain/main/BUILD.bazel
@@ -35,3 +35,18 @@ ts_project(
     out_dir = "config_target",
     tsconfig = ":tsconfig_node_extension",
 )
+
+# Further extending the tsconfig while also using isolated_typecheck
+ts_project(
+    name = "tsconfig_isolated_target",
+    srcs = ["main.ts"],
+    extends = ":tsconfig_node_extension",
+    isolated_typecheck = True,
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "outDir": "isolated",
+            "isolatedDeclarations": True,
+        },
+    },
+)

--- a/examples/tsconfig_types/BUILD.bazel
+++ b/examples/tsconfig_types/BUILD.bazel
@@ -18,7 +18,27 @@ ts_project(
     tsconfig = ":config",
 )
 
+# Also test isolated typechecking where the deps to tsc are reduced
+ts_project(
+    name = "ts-isolated",
+    srcs = [
+        "index.ts",
+    ],
+    extends = ":config",
+    isolated_typecheck = True,
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "outDir": "isolated",
+            "isolatedDeclarations": True,
+        },
+    },
+)
+
 build_test(
     name = "test",
-    targets = [":ts"],
+    targets = [
+        ":ts",
+        ":ts-isolated",
+    ],
 )


### PR DESCRIPTION
Fix #781

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Include tsconfig deps when invoking tsc even when `ts_project(isolated_typecheck)`.

### Test plan

- New test cases added
