### PR TITLE
refactor: move stardoc to docs submodule

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,8 @@
+# Nested modules
+docs/
 e2e/
+
+# TODO(bazel 8): move to REPO.bazel
 examples/connect_node/node_modules
 examples/node_modules
 examples/proto_grpc/node_modules

--- a/.bazelrc
+++ b/.bazelrc
@@ -16,11 +16,8 @@ common --incompatible_disallow_empty_glob
 
 # Never Compile protoc Again
 common --incompatible_enable_proto_toolchain_resolution
-
-# Ugh, stardoc needs to compile Java sources.
-# Don't depend on a JAVA_HOME pointing at a system JDK
-# see https://github.com/bazelbuild/rules_jvm_external/issues/445
-build --repo_env=JAVA_HOME=../bazel_tools/jdk
+common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
 
 # verbose
 common:verbose --@aspect_rules_ts//ts:verbose --worker_verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,9 @@ jobs:
         runs-on: ${{ matrix.os }}-latest
         needs:
             - matrix-prep
+        defaults:
+            run:
+                working-directory: ${{ matrix.folder }}
         strategy:
             fail-fast: false
             matrix:
@@ -105,7 +108,13 @@ jobs:
                       bzlmod: 0
                     - folder: e2e/workspace
                       bzlmod: 1
-
+                include:
+                    - bazel-version:
+                          major: 7
+                          version: 7.3.2
+                      bzlmod: 1
+                      folder: docs
+                      os: ubuntu
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -130,7 +139,6 @@ jobs:
                       bazel-cache-${{ matrix.bazel-version.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-
 
             - name: Configure Bazel version
-              working-directory: ${{ matrix.folder }}
               shell: bash
               run: |
                   # Overwrite the .bazelversion instead of using USE_BAZEL_VERSION so that Bazelisk
@@ -146,12 +154,10 @@ jobs:
             # TODO: remove this block once we have Aspect CLI Windows releases
             - name: Don't use Aspect CLI on Windows
               if: matrix.os == 'windows'
-              working-directory: ${{ matrix.folder }}
               shell: bash
               run: rm -f .bazeliskrc
 
             - name: bazel test //...
-              working-directory: ${{ matrix.folder }}
               shell: bash
               run: |
                   bazel \

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,16 +25,6 @@ bazel_dep(name = "aspect_rules_lint", version = "1.2.1", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
 bazel_dep(name = "rules_go", version = "0.46.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_nodejs", version = "6.2.0", dev_dependency = True)
-bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "toolchains_protoc", version = "0.3.0", dev_dependency = True)
-
-# Should not be required, stardoc leaks a dependency
-bazel_dep(name = "rules_java", version = "7.6.1", dev_dependency = True)
-
-register_toolchains(
-    "//tools/toolchains:all",
-    dev_dependency = True,
-)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,8 +1,0 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
-
-# Needed for stardoc to compile from Java sources
-http_jar(
-    name = "protobuf-java",
-    integrity = "sha256-kHLmD+Zs/11sDxGh3yHY8+Sym17ngrRcP8dfWfviuDk=",
-    urls = ["https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/4.27.0/protobuf-java-4.27.0.jar"],
-)

--- a/docs/.bazelversion
+++ b/docs/.bazelversion
@@ -1,0 +1,1 @@
+../.bazelversion

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -4,40 +4,18 @@ load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
 stardoc_with_diff_test(
     name = "rules",
-    bzl_library_target = "//ts:defs",
-    tags = [
-        "skip-on-bazel6",
-        "skip-on-bzlmod-0",
-        "skip-on-rbe",
-    ],
+    bzl_library_target = "@aspect_rules_ts//ts:defs",
 )
 
 stardoc_with_diff_test(
     name = "proto",
-    bzl_library_target = "//ts:proto",
-    tags = [
-        "skip-on-bazel6",
-        "skip-on-bzlmod-0",
-        "skip-on-rbe",
-    ],
+    bzl_library_target = "@aspect_rules_ts//ts:proto",
 )
 
 stardoc_with_diff_test(
     name = "repositories",
-    bzl_library_target = "//ts:repositories",
+    bzl_library_target = "@aspect_rules_ts//ts:repositories",
     symbol_names = ["rules_ts_dependencies"],
-    tags = [
-        "skip-on-bazel6",
-        "skip-on-bzlmod-0",
-        "skip-on-rbe",
-    ],
 )
 
-update_docs(
-    name = "update",
-    tags = [
-        "skip-on-bazel6",
-        "skip-on-bzlmod-0",
-        "skip-on-rbe",
-    ],
-)
+update_docs(name = "update")

--- a/docs/MODULE.bazel
+++ b/docs/MODULE.bazel
@@ -1,0 +1,8 @@
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "aspect_rules_ts", version = "0.0.0")
+bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_stardoc")
+
+local_path_override(
+    module_name = "aspect_rules_ts",
+    path = "..",
+)

--- a/tools/toolchains/BUILD.bazel
+++ b/tools/toolchains/BUILD.bazel
@@ -1,9 +1,0 @@
-load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
-
-proto_lang_toolchain(
-    name = "protoc_java_toolchain",
-    command_line = "--java_out=%s",
-    progress_message = "Generating Java proto_library %{label}",
-    runtime = "@protobuf-java//jar",
-    toolchain_type = "@rules_java//java/proto:toolchain_type",
-)

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -5,7 +5,7 @@ load("//ts/private:options.bzl", "options")
 
 exports_files(
     glob(["*.bzl"]),
-    visibility = ["//docs:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 _skip_lib_check_selection_required = """


### PR DESCRIPTION
Simplifies the method of avoiding compile of protoc from source in root repository

Partially reverts #614
