### PR TITLE
refactor: don't build protoc in docs either, it's the slowest CI step

### DIFF
--- a/docs/.bazelrc
+++ b/docs/.bazelrc
@@ -1,0 +1,5 @@
+# Never Compile protoc Again
+# Don't build protoc from the cc_binary, it's slow and spammy when cache miss
+common --per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --host_per_file_copt=external/.*protobuf.*@--PROTOBUF_WAS_NOT_SUPPOSED_TO_BE_BUILT
+common --java_runtime_version=remotejdk_11

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -2,19 +2,28 @@
 # so that the dependency on stardoc doesn't leak to them.
 load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
 
+java_binary(
+    name = "renderer",
+    main_class = "com/google/devtools/build/stardoc/renderer/RendererMain",
+    runtime_deps = ["@stardoc-prebuilt//jar"],
+)
+
 stardoc_with_diff_test(
     name = "rules",
     bzl_library_target = "@aspect_rules_ts//ts:defs",
+    renderer = "renderer",
 )
 
 stardoc_with_diff_test(
     name = "proto",
     bzl_library_target = "@aspect_rules_ts//ts:proto",
+    renderer = "renderer",
 )
 
 stardoc_with_diff_test(
     name = "repositories",
     bzl_library_target = "@aspect_rules_ts//ts:repositories",
+    renderer = "renderer",
     symbol_names = ["rules_ts_dependencies"],
 )
 

--- a/docs/MODULE.bazel
+++ b/docs/MODULE.bazel
@@ -6,3 +6,11 @@ local_path_override(
     module_name = "aspect_rules_ts",
     path = "..",
 )
+
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+http_jar(
+    name = "stardoc-prebuilt",
+    integrity = "sha256-jDi5ITmziwwiHCsfd8v0UOoraWXIAfICIll+wbpg/vE=",
+    urls = ["https://github.com/alexeagle/stardoc-prebuilt/releases/download/v0.7.1/renderer_deploy.jar"],
+)


### PR DESCRIPTION
follow-up to #792 

I made an incredibly simple GHA at https://github.com/alexeagle/stardoc-prebuilt to give the JAR file we need
