### PR TITLE
fix: source dts files outputted to outDir

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -27,6 +27,20 @@ npm_link_package(
 )
 
 npm_link_package(
+    name = "node_modules/@myorg/dts_pkg-outDir",
+    src = "//examples/dts_pkg-outDir:pkg",
+    root_package = "examples",
+    visibility = ["//examples:__subpackages__"],
+)
+
+npm_link_package(
+    name = "node_modules/@myorg/dts_pkg-outDir-rootDir",
+    src = "//examples/dts_pkg-outDir-rootDir:pkg",
+    root_package = "examples",
+    visibility = ["//examples:__subpackages__"],
+)
+
+npm_link_package(
     name = "node_modules/@myorg/lib_nocompile",
     src = "//examples/lib_nocompile:pkg",
     package = "@myorg/lib_nocompile",

--- a/examples/deps_pkg/BUILD.bazel
+++ b/examples/deps_pkg/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 ts_config(
     name = "tsconfig",
@@ -46,5 +47,17 @@ ts_project(
     declaration = True,
     deps = [
         "//examples:node_modules/@myorg/deps_pkg",
+    ],
+)
+
+build_test(
+    name = "test",
+    targets = [
+        ":importer_rel_ts",
+        "importer_rel.js",
+        "importer_rel.d.ts",
+        ":importer_linked_ts",
+        "importer_linked.js",
+        "importer_linked.d.ts",
     ],
 )

--- a/examples/deps_pkg_transpiler/BUILD.bazel
+++ b/examples/deps_pkg_transpiler/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//examples/transpiler:babel.bzl", "babel")
 
 ts_config(
@@ -50,5 +51,17 @@ ts_project(
     transpiler = babel,
     deps = [
         "//examples:node_modules/@myorg/deps_pkg_transpiler",
+    ],
+)
+
+build_test(
+    name = "test",
+    targets = [
+        ":importer_rel_ts",
+        "importer_rel.js",
+        "importer_rel.d.ts",
+        ":importer_linked_ts",
+        "importer_linked.js",
+        "importer_linked.d.ts",
     ],
 )

--- a/examples/dts_pkg-outDir-rootDir/BUILD.bazel
+++ b/examples/dts_pkg-outDir-rootDir/BUILD.bazel
@@ -5,37 +5,35 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 ts_project(
     name = "lib",
     srcs = [
-        "index.ts",
-        "lib_types.d.ts",
-        "lib_types_2.d.mts",
+        "src/index.ts",
+        "src/lib_types.d.ts",
+        "src/lib_types_2.d.mts",
     ],
     declaration = True,
     out_dir = "dist",
+    root_dir = "src",
     visibility = ["//examples:__subpackages__"],
 )
 
 npm_package(
     name = "pkg",
     srcs = [":lib"],
-    package = "@myorg/dts_pkg-outDir",
+    package = "@myorg/dts_pkg-outDir-rootDir",
     visibility = ["//examples:__subpackages__"],
 )
 
 ts_project(
     name = "importer_linked_ts",
-    srcs = ["importer_linked.ts"],
+    srcs = ["src/importer_linked.ts"],
     declaration = True,
     out_dir = "dist",
+    root_dir = "src",
     deps = [
-        "//examples:node_modules/@myorg/dts_pkg-outDir",
+        "//examples:node_modules/@myorg/dts_pkg-outDir-rootDir",
     ],
 )
 
 build_test(
     name = "importer_linked_test",
-    targets = [
-        ":importer_linked_ts",
-        "dist/importer_linked.js",
-        "dist/importer_linked.d.ts",
-    ],
+    targets = [":importer_linked_ts"],
 )

--- a/examples/dts_pkg-outDir-rootDir/src/importer_linked.ts
+++ b/examples/dts_pkg-outDir-rootDir/src/importer_linked.ts
@@ -1,0 +1,4 @@
+import { A, B } from '@myorg/dts_pkg-outDir-rootDir/dist'
+
+export const a: A = 42
+export const b: B = 'Forty Two'

--- a/examples/dts_pkg-outDir-rootDir/src/index.ts
+++ b/examples/dts_pkg-outDir-rootDir/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib_types'
+export * from './lib_types_2.mjs'

--- a/examples/dts_pkg-outDir-rootDir/src/lib_types.d.ts
+++ b/examples/dts_pkg-outDir-rootDir/src/lib_types.d.ts
@@ -1,0 +1,1 @@
+export type A = number

--- a/examples/dts_pkg-outDir-rootDir/src/lib_types_2.d.mts
+++ b/examples/dts_pkg-outDir-rootDir/src/lib_types_2.d.mts
@@ -1,0 +1,1 @@
+export type B = string

--- a/examples/dts_pkg-outDir-rootDir/tsconfig.json
+++ b/examples/dts_pkg-outDir-rootDir/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "outDir": "dist",
+        "rootDir": "src"
+    }
+}

--- a/examples/dts_pkg-outDir/importer_linked.ts
+++ b/examples/dts_pkg-outDir/importer_linked.ts
@@ -1,4 +1,4 @@
-import { A, B } from '@myorg/dts_pkg'
+import { A, B } from '@myorg/dts_pkg-outDir/dist'
 
 export const a: A = 42
 export const b: B = 'Forty Two'


### PR DESCRIPTION
https://github.com/aspect-build/rules_ts/pull/746/ changed this logic to align with outputted .js files which I think makes sense. However js also has the `allowJs` logic while dts files do not.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes/no

### Test plan

- Covered by existing test cases
- New test cases added
