### PR TITLE
fix: ensure typecheck test target is declared when isolated_typecheck=true

### DIFF
--- a/examples/isolated_typecheck/backend/BUILD.bazel
+++ b/examples/isolated_typecheck/backend/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_outputs")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 ts_project(
     name = "backend",
@@ -13,4 +14,14 @@ assert_outputs(
     name = "test_backend_default_outputs",
     actual = "backend",
     expected = ["examples/isolated_typecheck/backend/index.js"],
+)
+
+build_test(
+    name = "targets_test",
+    targets = [
+        ":backend",
+        ":backend_types",
+        ":backend_typecheck",
+        ":backend_typecheck_test",
+    ],
 )

--- a/examples/isolated_typecheck/core/BUILD.bazel
+++ b/examples/isolated_typecheck/core/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 ts_project(
     name = "core",
@@ -6,4 +7,14 @@ ts_project(
     isolated_typecheck = True,
     tsconfig = "//examples/isolated_typecheck:tsconfig",
     visibility = ["//examples/isolated_typecheck:__subpackages__"],
+)
+
+build_test(
+    name = "targets_test",
+    targets = [
+        ":core",
+        ":core_types",
+        ":core_typecheck",
+        ":core_typecheck_test",
+    ],
 )

--- a/examples/isolated_typecheck/frontend/BUILD.bazel
+++ b/examples/isolated_typecheck/frontend/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 ts_project(
     name = "frontend",
@@ -10,4 +11,14 @@ ts_project(
         },
     },
     deps = ["//examples/isolated_typecheck/core"],
+)
+
+build_test(
+    name = "targets_test",
+    targets = [
+        ":frontend",
+        ":frontend_types",
+        ":frontend_typecheck",
+        ":frontend_typecheck_test",
+    ],
 )

--- a/examples/no_emit/BUILD.bazel
+++ b/examples/no_emit/BUILD.bazel
@@ -45,8 +45,10 @@ ts_project(
 build_test(
     name = "targets_test",
     targets = [
-        # Ensure the _typecheck targets are declared despite no outputs.
+        # Ensure the _typecheck and _test targets are declared despite no outputs.
         ":typecheck_only_noemit_typecheck",
+        ":typecheck_only_noemit_typecheck_test",
         ":typecheck_nodeclarations_js_typecheck",
+        ":typecheck_nodeclarations_js_typecheck_test",
     ],
 )

--- a/examples/transpiler/BUILD.bazel
+++ b/examples/transpiler/BUILD.bazel
@@ -102,6 +102,7 @@ build_test(
         # babel ts_project
         ":babel",
         ":babel_typecheck",
+        ":babel_typecheck_test",
         # babel outputted js
         "big.js",  # NOTE: does not implement out_dir in this test
         # tsc outputted dts
@@ -110,10 +111,12 @@ build_test(
         # no-emit for type-checking
         ":no-emit",
         ":no-emit_typecheck",
+        ":no-emit_typecheck_test",
 
         # babel outputted .js with no declarations
         ":no-declarations",
         ":no-declarations_typecheck",
+        ":no-declarations_typecheck_test",
         "a.js",  # NOTE: does not implement out_dir in this test
     ],
 )
@@ -162,6 +165,7 @@ build_test(
         ":custom_transpilers",
         ":custom_transpilers_types",
         ":custom_transpilers_typecheck",
+        ":custom_transpilers_typecheck_test",
         "build-custom_transpilers/a.js",
         "build-custom_transpilers/a.d.ts",
     ],
@@ -232,6 +236,7 @@ build_test(
         ":custom_dts_transpiler",
         ":custom_dts_transpiler_types",
         ":custom_dts_transpiler_typecheck",
+        ":custom_dts_transpiler_typecheck_test",
         "build-custom_dts_transpiler/a.js",
         "build-custom_dts_transpiler/a.d.ts",
     ],
@@ -261,6 +266,7 @@ build_test(
     targets = [
         ":custom_dts_transpiler-no_declarations",
         ":custom_dts_transpiler-no_declarations_typecheck",
+        ":custom_dts_transpiler-no_declarations_typecheck_test",
         "build-custom_dts_transpiler-no_declarations/a.js",
     ],
 )
@@ -288,6 +294,7 @@ build_test(
     targets = [
         ":custom_dts_transpiler-declarations_only",
         ":custom_dts_transpiler-declarations_only_typecheck",
+        ":custom_dts_transpiler-declarations_only_typecheck_test",
         "build-custom_dts_transpiler-no_declarations/a.d.ts",
     ],
 )

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -404,7 +404,7 @@ def ts_project(
             )
 
     # If the primary target does not output dts files then type-checking has a separate target.
-    if not emit_tsc_js or not emit_tsc_dts:
+    if not emit_tsc_js or not emit_tsc_dts or isolated_typecheck:
         typecheck_target_name = "%s_typecheck" % name
         transitive_typecheck_target_name = "%s_transitive_typecheck" % name
         test_target_name = "%s_typecheck_test" % name


### PR DESCRIPTION
Fix #817

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Ensure tsc is run by a test for type-checking when `isolated_typecheck=True`

### Test plan

- New test cases added
