### PR TITLE
chore: fix release_prep reference to snippet in e2e/smoke/WORKSPACE

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -46,7 +46,7 @@ http_archive(
 )
 EOF
 
-awk 'f;/--SNIP--/{f=1}' e2e/workspace/WORKSPACE
+awk 'f;/--SNIP--/{f=1}' e2e/smoke/WORKSPACE
 echo "\`\`\`"
 
 cat <<EOF


### PR DESCRIPTION
Most likely broken from https://github.com/aspect-build/rules_ts/commit/264f5bdafd7d4d4ab63acc85e26da55a3f217c2c

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: guess
