### PR TITLE
chore: dedupe alex in bcr metadata

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -20,11 +20,6 @@
             "name": "Sahin Yort",
             "email": "sahin@aspect.build",
             "github": "thesayyn"
-        },
-        {
-            "name": "Alex Eagle",
-            "email": "alex@aspect.build",
-            "github": "alexeagle"
         }
     ],
     "repository": ["github:aspect-build/rules_ts"],


### PR DESCRIPTION
I think this is causing https://buildkite.com/bazel/bcr-presubmit/builds/15966#0197d709-2d0a-4aaf-8578-98d215a91843 because only [one of the Alex's](https://github.com/bazelbuild/bazel-central-registry/blob/5a2654cd2ec696ef6f3e1e3ae5c2116da33446ed/modules/aspect_rules_ts/metadata.json#L8) has the `github_user_id` being added on BCR.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce: guess
