### PR TITLE
Demonstrate issue with `isolated_typecheck`

### DIFF
--- a/examples/isolated_typecheck/backend/BUILD.bazel
+++ b/examples/isolated_typecheck/backend/BUILD.bazel
@@ -6,8 +6,11 @@ ts_project(
     name = "backend",
     declaration = True,
     isolated_typecheck = True,
-    tsconfig = "//examples/isolated_typecheck:tsconfig",
-    deps = ["//examples/isolated_typecheck/core"],
+    tsconfig = "tsconfig.json",
+    deps = [
+        "//examples/isolated_typecheck/core",
+        "//examples:node_modules/@types/node",
+    ],
 )
 
 assert_outputs(

--- a/examples/isolated_typecheck/backend/tsconfig.json
+++ b/examples/isolated_typecheck/backend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "isolatedDeclarations": true,
+        "declaration": true,
+        "types": ["node"]
+    }
+}


### PR DESCRIPTION
```
$ bazel build //examples/isolated_typecheck/backend
INFO: Analyzed target //examples/isolated_typecheck/backend:backend (97 packages loaded, 6455 targets configured).
ERROR: /Users/john/figma/rules_ts/examples/isolated_typecheck/backend/BUILD.bazel:5:11: Transpiling TypeScript project @@//examples/isolated_typecheck/backend:backend [tsc -p examples/isolated_typecheck/backend/tsconfig.json] failed: (Exit 2): tsc failed: error executing TsProjectEmit command (from target //examples/isolated_typecheck/backend:backend) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/_main~ext~npm_typescript/tsc_/tsc --project examples/isolated_typecheck/backend/tsconfig.json --rootDir examples/isolated_typecheck/backend ... (remaining 3 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
Target //examples/isolated_typecheck/backend:backend failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 6.382s, Critical Path: 0.71s
INFO: 20 processes: 12 internal, 3 darwin-sandbox, 5 local.
ERROR: Build did NOT complete successfully
```

