### PR TITLE
feat: add --@aspect_rules_ts//ts:validation_typecheck config for type-checking as a validation action

### DIFF
--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -93,6 +93,12 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "validation_typecheck",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 # Note, users could use a Transition to make a subgraph of their depgraph opt-in to skipLibCheck.
 config_setting(
     name = "skip_lib_check.always",
@@ -132,6 +138,13 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "validation_typecheck_flag",
+    flag_values = {
+        ":validation_typecheck": "true",
+    },
+)
+
 options(
     name = "options",
     default_to_tsc_transpiler = select({
@@ -151,6 +164,10 @@ options(
     ),
     supports_workers = select({
         ":supports_workers_flag": True,
+        "//conditions:default": False,
+    }),
+    validation_typecheck = select({
+        ":validation_typecheck_flag": True,
         "//conditions:default": False,
     }),
     verbose = select({

--- a/ts/private/options.bzl
+++ b/ts/private/options.bzl
@@ -13,7 +13,7 @@ Please read https://docs.aspect.build/rules/aspect_rules_ts/docs/transpiler
 
 OptionsInfo = provider(
     doc = "Internal: Provider that carries verbosity and global worker support information.",
-    fields = ["args", "default_to_tsc_transpiler", "verbose", "supports_workers", "generate_tsc_trace"],
+    fields = ["args", "default_to_tsc_transpiler", "verbose", "supports_workers", "generate_tsc_trace", "validation_typecheck"],
 )
 
 def _options_impl(ctx):
@@ -48,6 +48,7 @@ def _options_impl(ctx):
         supports_workers = ctx.attr.supports_workers,
         default_to_tsc_transpiler = ctx.attr.default_to_tsc_transpiler,
         generate_tsc_trace = ctx.attr.generate_tsc_trace,
+        validation_typecheck = ctx.attr.validation_typecheck,
     )
 
 options = rule(
@@ -58,5 +59,6 @@ options = rule(
         "supports_workers": attr.bool(),
         "skip_lib_check": attr.bool(),
         "generate_tsc_trace": attr.bool(),
+        "validation_typecheck": attr.bool(),
     },
 )

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -367,6 +367,9 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
     output_types_depset = depset(output_types)
     output_sources_depset = depset(output_sources)
 
+    if options.validation_typecheck:
+        validation_outs.extend(typecheck_outs)
+
     # Align runfiles config with rules_js js_library() to align behaviour.
     # See https://github.com/aspect-build/rules_js/blob/v2.1.0/js/private/js_library.bzl#L241-L254
     runfiles = js_lib_helpers.gather_runfiles(


### PR DESCRIPTION
In some scenarios devs or organizations want type-checking on, maybe opt-in via `--config`, maybe 100% via bazelrc. This provides type-checking via validation action

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
