### PR TITLE
feat: allow ts_project to point to the eslint config

### DIFF
--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -96,6 +96,14 @@ https://docs.aspect.build/rulesets/aspect_rules_js/docs/js_library#deps for more
         mandatory = True,
         allow_single_file = [".json"],
     ),
+    "eslintconfig": attr.label(
+        doc = """.eslintrc file, or other filenames accepted by ESLint.
+        see https://eslint.org/docs/latest/use/configure/configuration-files
+        Note, this is unused in rules_ts, but exists to allow the information to propagate through the dependency graph.
+        For example, it can be used by the eslint aspect in Aspect's rules_lint.
+        """,
+        allow_single_file = True,
+    ),
     "isolated_typecheck": attr.bool(
         doc = """\
         Whether type-checking should be a separate action.


### PR DESCRIPTION
ESLint flat config is not ergonomic in a monorepo. Many projects would prefer to have the eslint config locally, for example one-per-package.json

See https://github.com/aspect-build/rules_lint/compare/main...eslint_no_flat for how this may be used.

FYI @jfirebaugh @walkerburgin 