### PR TITLE
chore: update tools_telemetry to 0.2.8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
 bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
-bazel_dep(name = "aspect_tools_telemetry", version = "0.2.6")
+bazel_dep(name = "aspect_tools_telemetry", version = "0.2.8")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "0.0.5")

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -140,6 +140,7 @@ bzl_library(
         "//ts/private:ts_config",
         "//ts/private:ts_project",
         "@aspect_rules_js//js:defs",
+        "@aspect_tools_telemetry_report//:defs.bzl",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//rules:build_test",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -5,6 +5,7 @@ inputs and produces JavaScript or declaration (.d.ts) outputs.
 """
 
 load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
+load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("//ts/private:build_test.bzl", "build_test")
 load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -2,7 +2,6 @@
 See https://bazel.build/docs/bzlmod#extension-definition
 """
 
-load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION")
 load("//ts/private:npm_repositories.bzl", "npm_dependencies")
 

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -49,6 +49,13 @@ def rules_ts_bazel_dependencies():
         url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz",
     )
 
+    http_archive(
+        name = "aspect_tools_telemetry_report",
+        sha256 = "fea3bc2f9b7896ab222756c27147b1f1b8f489df8114e03d252ffff475f8bce6",
+        strip_prefix = "tools_telemetry-0.2.8",
+        url = "https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz",
+    )
+
 def rules_ts_dependencies(name = "npm_typescript", ts_version_from = None, ts_version = None, ts_integrity = None):
     """Dependencies needed by users of rules_ts.
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
