### PR TITLE
fix: allow out_dir to be an empty string in validator

### DIFF
--- a/ts/private/ts_project_options_validator.cjs
+++ b/ts/private/ts_project_options_validator.cjs
@@ -105,7 +105,7 @@ function main(_a) {
     function check_out_dir() {
         var attr = 'out_dir'
         var optionVal = getTsOption('outDir')
-        var attrIsFalsyOrUndefined = attrs[attr] === false || attrs[attr] === '' || attrs[attr] === undefined
+        var attrIsFalsyOrUndefined = attrs[attr] === false || attrs[attr] === undefined
         if (attrIsFalsyOrUndefined && optionVal !== undefined) {
             throw new Error(
                 'When outDir is set in the tsconfig it must also be set in the ts_project' +


### PR DESCRIPTION
ts_project sets the out_dir to None if it's "." or "./" which makes it as if it is not set or effectively an empty string. 

The validator then checks of the ts_project rule has an out_dir set if the tsconfig has it set, but it gets stripped by the ts_project thus the validator fails with an error saying the rule does not match tsconfig - when from our perspective it does but rules_ts is removing it.

Example error:
```
Error: When outDir is set in the tsconfig it must also be set in the ts_project rule, so that the output directory is known to Bazel.
```

The mangling of out_dir "." / "./" to be None should probably be handled deeper in `ts_project_rule` itself ?

### Test plan

Tested in the sourcegraph repo:

`MODULE.bazel`
```
bazel_dep(name = "aspect_rules_ts", version = "3.7.0")
local_path_override(module_name = "aspect_rules_ts", path = "/Users/william/code/rules_ts")
```
We modified our `ts_project` macro to do the following
```
    tsconfig = kwargs.pop("tsconfig", "//:tsconfig")
    if type(tsconfig) == dict:
        fail("tsconfig MUST be a label and not a dict")


    # Default arguments for ts_project.
    _ts_project(
        name = name,
        srcs = srcs,
        deps = deps,
        transpiler = transpiler,

        out_dir = ".",
        tsconfig = { "compilerOptions": { "outDir": "." }},
        # We extend tsconfig to overwrite the out_dir to recreate the behaviour we have in rules_ts 3.2
        extends = tsconfig,
```

Then invoked one of our client targets `bazel test //client/common:test`