### PR TITLE
fix: trigger auto-release when updating typescript version

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -17,4 +17,4 @@ jobs:
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v5
               with:
-                  commit-message: 'chore: mirror external releases'
+                  commit-message: 'fix: add latest ts external release hashes'


### PR DESCRIPTION
The conventional commits spec we use in https://github.com/aspect-build/rules_ts/blob/main/.github/workflows/tag.yaml#L31-L33 won't pick up chore, but will pick up fix and push a new patch.

fixes #857
