### PR TITLE
repro #476

### DIFF
--- a/examples/proto_grpc/BUILD.bazel
+++ b/examples/proto_grpc/BUILD.bazel
@@ -16,6 +16,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//examples/connect_node/proto:eliza_proto",
+        "//examples/proto_grpc/stripping:s_proto",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/examples/proto_grpc/logger.proto
+++ b/examples/proto_grpc/logger.proto
@@ -5,6 +5,7 @@ package logger;
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "examples/connect_node/proto/eliza.proto";
+import "post-stripped/proto_grpc/stripping/s.proto";
 
 service Logger {
   rpc SendLogMessage(LogMessage) returns (Empty) {}
@@ -15,6 +16,7 @@ message LogMessage {
   google.protobuf.Timestamp time = 2;
   google.protobuf.Any details = 3;
   connectrpc.eliza.v1.SayRequest say_request = 4;
+  proto_grpc.stripping.Empty empty = 5;
 }
 
 message Empty {}

--- a/examples/proto_grpc/stripping/s.proto
+++ b/examples/proto_grpc/stripping/s.proto
@@ -1,3 +1,5 @@
 syntax = "proto3";
 
+package proto_grpc.stripping;
+
 message Empty {}

--- a/ts/private/ts_proto_library.bzl
+++ b/ts/private/ts_proto_library.bzl
@@ -135,6 +135,7 @@ def _protoc_action(ctx, proto_info, outputs):
 
 def _declare_outs(ctx, info, ext):
     outs = proto_common.declare_generated_files(ctx.actions, info, "_pb" + ext)
+    print(outs)
     if ctx.attr.gen_connect_es:
         outs.extend(proto_common.declare_generated_files(ctx.actions, info, "_connect" + ext))
     if ctx.attr.gen_connect_query:


### PR DESCRIPTION
#819 was incomplete - while it reproduced building a ts_proto_library with a strip_import_prefix, it did not exercise it.
The error comes from the `_virtual_imports/` pathing that protobuf introduces in `proto_common.declare_generated_files` - it has to be accounted for in *every* location that resolves the resulting files in bazel-out.

```
# Production site
alexeagle@aspect-build examples % bazel build //examples/proto_grpc/stripping:s_ts_proto
DEBUG: /Users/alexeagle/Projects/rules_ts/ts/private/ts_proto_library.bzl:138:10: [<generated file examples/proto_grpc/stripping/_virtual_imports/s_proto/post-stripped/proto_grpc/stripping/s_pb.js>]
DEBUG: /Users/alexeagle/Projects/rules_ts/ts/private/ts_proto_library.bzl:138:10: [<generated file examples/proto_grpc/stripping/_virtual_imports/s_proto/post-stripped/proto_grpc/stripping/s_pb.d.ts>]
INFO: Analyzed target //examples/proto_grpc/stripping:s_ts_proto (14 packages loaded, 5385 targets configured).
INFO: Found 1 target...
Target //examples/proto_grpc/stripping:s_ts_proto up-to-date:
  bazel-bin/examples/proto_grpc/stripping/_virtual_imports/s_proto/post-stripped/proto_grpc/stripping/s_pb.js

# Use site: proto descriptor works
alexeagle@aspect-build examples % bazel build //examples/proto_grpc:logger_proto 
INFO: Analyzed target //examples/proto_grpc:logger_proto (0 packages loaded, 8 targets configured).
INFO: Found 1 target...
Target //examples/proto_grpc:logger_proto up-to-date:
  bazel-bin/examples/proto_grpc/logger_proto-descriptor-set.proto.bin
INFO: Elapsed time: 0.075s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

# Use site: ts consumer does not resolve
alexeagle@aspect-build examples % bazel build //examples/proto_grpc/...
DEBUG: /Users/alexeagle/Projects/rules_ts/ts/private/ts_proto_library.bzl:138:10: [<generated file examples/proto_grpc/stripping/_virtual_imports/s_proto/post-stripped/proto_grpc/stripping/s_pb.js>]
DEBUG: /Users/alexeagle/Projects/rules_ts/ts/private/ts_proto_library.bzl:138:10: [<generated file examples/proto_grpc/stripping/_virtual_imports/s_proto/post-stripped/proto_grpc/stripping/s_pb.d.ts>]
INFO: Analyzed 32 targets (3 packages loaded, 82 targets configured).
ERROR: /Users/alexeagle/Projects/rules_ts/examples/proto_grpc/BUILD.bazel:53:11: Transpiling (js) & type-checking TypeScript project @@//examples/proto_grpc:proto_grpc [tsc -p examples/proto_grpc/tsconfig.json] failed: (Exit 2): tsc failed: error executing TsProject command (from target //examples/proto_grpc:proto_grpc) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/_main~ext~npm_typescript/tsc_/tsc --project examples/proto_grpc/tsconfig.json --rootDir examples/proto_grpc --declaration false

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
examples/proto_grpc/logger_pb.d.ts(9,39): error TS2307: Cannot find module '../../post-stripped/proto_grpc/stripping/s_pb.js' or its corresponding type declarations.
Use --verbose_failures to see the command lines of failed build steps.
```
