### PR TITLE
refactor: prepare support for rules_js v3

### DIFF
--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -65,10 +65,9 @@ def _ts_config_impl(ctx):
 
     files_depset = depset(files)
 
+    # tsconfig.json file won't be needed at runtime
     runfiles = js_lib_helpers.gather_runfiles(
         ctx = ctx,
-        sources = depset(),  # tsconfig.json file won't be needed at runtime
-        data = [],
         deps = ctx.attr.deps,
     )
 

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -372,22 +372,17 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
     if options.validation_typecheck:
         validation_outs.extend(typecheck_outs)
 
-    # Align runfiles config with rules_js js_library() to align behaviour.
+    # Align runfiles config with rules_js js_library() to align behaviour, do not set attributes
+    # unless explicitly overriding the rules_js defaults.
     # See https://github.com/aspect-build/rules_js/blob/v2.1.0/js/private/js_library.bzl#L241-L254
     runfiles = js_lib_helpers.gather_runfiles(
         ctx = ctx,
-        sources = output_sources_depset,
         data = ctx.attr.data,
         deps = srcs_deps,
         data_files = ctx.files.data,
         copy_data_files_to_bin = True,  # NOTE: configurable (default true) in js_library()
         no_copy_to_bin = [],  # NOTE: configurable (default []) in js_library()
-        include_sources = True,
-        include_types = False,
-        include_transitive_sources = True,
-        include_transitive_types = False,
-        include_npm_sources = True,
-    )
+    ).merge(ctx.runfiles(transitive_files = depset(transitive = [output_sources_depset])))
 
     providers = [
         DefaultInfo(


### PR DESCRIPTION
This should have no change when used with rules_js v2, while making it compatible with rules_js v3 after https://github.com/aspect-build/rules_js/pull/2615

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
