### PR TITLE
chore: remove unnecessary aspect_bazel_lib version override in tests

### DIFF
--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -1,16 +1,6 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "aspect_rules_ts",
     path = "../..",
-)
-
-# Override the version declared by rules_ts for windows fix
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
-    strip_prefix = "bazel-lib-2.9.0",
-    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")

--- a/e2e/external_dep/app/MODULE.bazel
+++ b/e2e/external_dep/app/MODULE.bazel
@@ -4,12 +4,6 @@ local_path_override(
     path = "../../..",
 )
 
-# Override the version declared by rules_ts for windows fix
-single_version_override(
-    module_name = "aspect_bazel_lib",
-    version = "2.9.0",
-)
-
 # TODO: see note on rules_js in the parent MODULE.bazel
 bazel_dep(name = "aspect_rules_js", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)

--- a/e2e/external_dep/app/WORKSPACE
+++ b/e2e/external_dep/app/WORKSPACE
@@ -1,5 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "aspect_rules_ts",
     path = "../../..",
@@ -8,14 +6,6 @@ local_repository(
 local_repository(
     name = "lib_wksp",
     path = "..",
-)
-
-# Override the version declared by rules_ts for windows fix
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
-    strip_prefix = "bazel-lib-2.9.0",
-    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
 )
 
 load("@aspect_rules_ts//ts:repositories.bzl", "LATEST_TYPESCRIPT_VERSION", "rules_ts_dependencies")

--- a/e2e/smoke/WORKSPACE
+++ b/e2e/smoke/WORKSPACE
@@ -6,14 +6,6 @@ local_repository(
     path = "../..",
 )
 
-# Override the version declared by rules_ts for windows fix
-http_archive(
-    name = "aspect_bazel_lib",
-    sha256 = "9a44f457810ce64ec36a244cc7c807607541ab88f2535e07e0bf2976ef4b73fe",
-    strip_prefix = "bazel-lib-2.19.4",
-    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.19.4/bazel-lib-v2.19.4.tar.gz",
-)
-
 http_archive(
     name = "rules_proto",
     sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
