### PR TITLE
test: add rules_js v3 e2e test

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -27,6 +27,18 @@ workspaces:
                   without: true
             - buildifier:
                   without: true
+    e2e/rules_js_v3:
+        tasks:
+            - bazel-6:
+                  without: true
+            - bazel-7:
+                  queue: aspect-medium
+            - bazel-8:
+                  queue: aspect-medium
+            - format:
+                  without: true
+            - buildifier:
+                  without: true
     e2e/external_dep:
         tasks:
             - bazel-6:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
                     - '.'
                     - 'e2e/smoke'
                     - 'e2e/bzlmodules'
+                    - 'e2e/rules_js_v3'
                     - 'e2e/external_dep'
                     - 'e2e/external_dep/app'
                     - 'e2e/worker'
@@ -108,10 +109,16 @@ jobs:
                     # bzlmod only tests
                     - bzlmod: 0
                       folder: e2e/bzlmodules
+                    - bzlmod: 0
+                      folder: e2e/rules_js_v3
                     # TODO: e2e/smoke broken with bazel6
                     - bazel-version:
                           major: 6
                       folder: e2e/smoke
+                    # rules_js v3 requires newer Bazel
+                    - bazel-version:
+                          major: 6
+                      folder: e2e/rules_js_v3
                     # TODO: broken on bazel 8
                     - bazel-version:
                           major: 8

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -4,12 +4,6 @@ local_path_override(
     path = "../..",
 )
 
-# Override the version declared by rules_ts for windows fix
-single_version_override(
-    module_name = "aspect_bazel_lib",
-    version = "2.9.0",
-)
-
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)

--- a/e2e/rules_js_v3/.bazelrc
+++ b/e2e/rules_js_v3/.bazelrc
@@ -1,0 +1,4 @@
+import %workspace%/../../tools/preset.bazelrc
+
+common --@aspect_rules_ts//ts:skipLibCheck=always
+common --@aspect_rules_ts//ts:default_to_tsc_transpiler

--- a/e2e/rules_js_v3/BUILD.bazel
+++ b/e2e/rules_js_v3/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+)
+
+ts_project(
+    name = "lib",
+    srcs = ["lib.ts"],
+    declaration = True,
+    source_map = True,
+    tsconfig = ":tsconfig",
+)
+
+build_test(
+    name = "test",
+    targets = [
+        ":lib",
+        ":lib_types",
+    ],
+)

--- a/e2e/rules_js_v3/MODULE.bazel
+++ b/e2e/rules_js_v3/MODULE.bazel
@@ -1,0 +1,19 @@
+"Basic e2e test for rules_js v3"
+
+module(name = "rules_js_v3_test")
+
+bazel_dep(name = "aspect_rules_ts", version = "0.0.0")
+local_path_override(
+    module_name = "aspect_rules_ts",
+    path = "../..",
+)
+
+bazel_dep(name = "aspect_rules_js", version = "3.0.0-alpha.4")
+
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
+
+rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
+rules_ts_ext.deps(
+    ts_version_from = "//:package.json",
+)
+use_repo(rules_ts_ext, "npm_typescript")

--- a/e2e/rules_js_v3/WORKSPACE
+++ b/e2e/rules_js_v3/WORKSPACE
@@ -1,0 +1,1 @@
+# EMPTY - this test is designed for bzlmod only

--- a/e2e/rules_js_v3/lib.ts
+++ b/e2e/rules_js_v3/lib.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+    return `Hello, ${name}!`
+}

--- a/e2e/rules_js_v3/package.json
+++ b/e2e/rules_js_v3/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "rules_js_v3_test",
+    "version": "1.0.0",
+    "private": true,
+    "packageManager": "pnpm@10.14.0",
+    "dependencies": {
+        "typescript": "5.8.3"
+    }
+}

--- a/e2e/rules_js_v3/pnpm-lock.yaml
+++ b/e2e/rules_js_v3/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
+packages:
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.8.3: {}

--- a/e2e/rules_js_v3/tsconfig.json
+++ b/e2e/rules_js_v3/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "module": "nodenext",
+        "target": "esnext",
+        "types": [],
+        "sourceMap": true,
+        "declaration": true,
+        "strict": true,
+        "isolatedModules": true,
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
This tests rules_js v3, major changes include:
* bazel 7.6+ only
* bzlmod only
* bazel-lib v3 (while rules_ts still uses aspect-bazel-lib v2)

### Changes are visible to end-users: no

### Test plan

- New test cases added
