### PR TITLE
fix(docs): worker mode no longer on by default starting in 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@ This is the canonical ruleset for using Bazel with TypeScript, based on
 
 Many companies are successfully building with rules_ts. If you're getting value from the project, please let us know! Just comment on our [Adoption Discussion](https://github.com/aspect-build/rules_js/discussions/1000).
 
-This is a high-performance alternative to the `@bazel/typescript` npm package from rules_nodejs.
-The `ts_project` rule here is identical to the one in rules_nodejs, making it easy to migrate.
-Since rules_js always runs tools from the bazel-out tree, rules_ts naturally fixes most usability bugs with rules_nodejs:
-
--   Freely mix generated `*.ts` and `tsconfig.json` files in the bazel-out tree with source files
--   Fixes the need for any `rootDirs` settings in `tsconfig.json` as reported in https://github.com/microsoft/TypeScript/issues/37378
--   "worker mode" for `ts_project` now shares workers across all targets, rather than requiring one worker pool per target
-
 rules_ts is just a part of what Aspect provides:
 
 -   _Need help?_ This ruleset has support provided by https://aspect.build/services.

--- a/docs/transpiler.md
+++ b/docs/transpiler.md
@@ -81,13 +81,6 @@ Just add this to `/.bazelrc``:
     # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
-    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
-    build --@aspect_rules_ts//ts:default_to_tsc_transpiler
-    fetch --@aspect_rules_ts//ts:default_to_tsc_transpiler
-    query --@aspect_rules_ts//ts:default_to_tsc_transpiler
-
-    # Before Bazel 6.0, only the 'build' and 'fetch' lines work.
-
 ### Other Transpilers
 
 The `transpiler` attribute accepts any rule or macro with this signature: `(name, srcs, **kwargs)`

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -70,10 +70,6 @@ def ts_project(
     Unlike bare `tsc`, this rule understands the Bazel interop mechanism (Providers)
     so that this rule works with others that produce or consume TypeScript typings (`.d.ts` files).
 
-    One of the benefits of using ts_project is that it understands the [Bazel Worker Protocol]
-    which makes the overhead of starting the compiler be a one-time cost.
-    Worker mode is on by default to speed up build and typechecking process.
-
     Some TypeScript options affect which files are emitted, and Bazel needs to predict these ahead-of-time.
     As a result, several options from the tsconfig file must be mirrored as attributes to ts_project.
     A validation action is run to help ensure that these are correctly mirrored.
@@ -81,8 +77,6 @@ def ts_project(
 
     If you have problems getting your `ts_project` to work correctly, read the dedicated
     [troubleshooting guide](/docs/troubleshooting.md).
-
-    [Bazel Worker Protocol]: https://bazel.build/remote/persistent
 
     Args:
         name: a name for this target

--- a/ts/private/options.bzl
+++ b/ts/private/options.bzl
@@ -35,25 +35,11 @@ You must choose exactly one of the following flags:
     # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:skipLibCheck=always
 
-    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
-    build --@aspect_rules_ts//ts:skipLibCheck=always
-    fetch --@aspect_rules_ts//ts:skipLibCheck=always
-    query --@aspect_rules_ts//ts:skipLibCheck=always
-
-    # Before Bazel 6.0, only the 'build' and 'fetch' lines work.
-
 2. To choose more correct typechecks, put this in /.bazelrc:
 
     # honor the setting of `skipLibCheck` in the tsconfig.json file
     # Bazel 6.4 or greater: 'common' means 'any command that supports this flag'
     common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-
-    # Between Bazel 6.0 and 6.3, you need all of this, to avoid discarding the analysis cache:
-    build --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-    fetch --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-    query --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
-
-    # Before Bazel 6.0, only the 'build' and 'fetch' lines work.
 
 ##########################################################
 """


### PR DESCRIPTION
The docs were inconsistent about it.

Also remove some Bazel 6.3 and earlier content, which is no longer supported since Bazel 6 exited LTS with the release of Bazel 9

@kapunahelewong for review (not a member of this repo yet so I can't add as reviewer)