### PR TITLE
test: fix examples module with Bazel 7

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -9,9 +9,8 @@ workspaces:
                   without: true
     examples:
         tasks:
-            # No Bazel7 in root/examples
             - bazel-7:
-                  without: true
+                  queue: aspect-medium
             # No WORKSPACE root/examples
             - bazel-7-wksp:
                   without: true

--- a/examples/.bazelignore
+++ b/examples/.bazelignore
@@ -1,0 +1,13 @@
+connect_node/node_modules
+connect_node/proto/node_modules
+lib_nocompile_linked/node_modules
+linked_consumer/node_modules
+linked_empty_node_modules/node_modules
+linked_lib/node_modules
+linked_pkg/node_modules
+linked_tsconfig/node_modules
+linked_tsconfig_consumer/node_modules
+node_modules
+proto_grpc/node_modules
+resolve_json_module/node_modules
+resolve_json_module_esm/node_modules

--- a/examples/REPO.bazel
+++ b/examples/REPO.bazel
@@ -1,2 +1,0 @@
-"See https://bazel.build/rules/lib/globals/repo"
-ignore_directories(["**/node_modules"])


### PR DESCRIPTION
Before this change, Bazel 7 could not build under examples/ due to the use of `ignore_directories()` in REPO.bazel. This change fixes the problem by deleting that file and going back to the older .bazelignore solution instead. I also updated the CI config to start testing the examples with Bazel 7.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases