### PR TITLE
fix: validate rootDir and outDir compatibility with rules_ts

### DIFF
--- a/e2e/test/validation.bats
+++ b/e2e/test/validation.bats
@@ -121,3 +121,65 @@ teardown() {
 	run bazel build :foo
 	assert_success
 }
+
+@test 'When rootDir in tsconfig resolves to a parent of the package, validation should fail' {
+	workspace
+
+	mkdir -p child
+	echo "export const a = 1;" >child/source.ts
+
+	cat >child/tsconfig.json <<EOF
+{
+    "compilerOptions": {
+        "rootDir": ".."
+    },
+    "exclude": []
+}
+EOF
+
+	cat >child/BUILD.bazel <<EOF
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "foo",
+    srcs = ["source.ts"],
+    tsconfig = "tsconfig.json",
+)
+EOF
+
+	run bazel build //child:foo
+	assert_failure
+	assert_output -p "rootDir in the tsconfig resolves to"
+	assert_output -p "which is a parent of the package directory"
+}
+
+@test 'When outDir in tsconfig resolves to a parent of the package, validation should fail' {
+	workspace
+
+	mkdir -p child
+	echo "export const a = 1;" >child/source.ts
+
+	cat >child/tsconfig.json <<EOF
+{
+    "compilerOptions": {
+        "outDir": ".."
+    },
+    "exclude": []
+}
+EOF
+
+	cat >child/BUILD.bazel <<EOF
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "foo",
+    srcs = ["source.ts"],
+    tsconfig = "tsconfig.json",
+)
+EOF
+
+	run bazel build //child:foo
+	assert_failure
+	assert_output -p "outDir in the tsconfig resolves to"
+	assert_output -p "which is a parent of the package directory"
+}

--- a/examples/root_dir/BUILD.bazel
+++ b/examples/root_dir/BUILD.bazel
@@ -6,6 +6,7 @@ despite their similar naming.
 
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_lib//lib:testing.bzl", "assert_outputs")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 # By default, TypeScript calculates rootDir as the closest common ancestor
 # so you'd expect outDir/a.ts to be produced.
@@ -94,4 +95,19 @@ assert_outputs(
         "root_dir/otherdir/a.js",
         "root_dir/otherdir/deep/subdir/b.js",
     ],
+)
+
+# A tsconfig that lives in a subfolder of the package can use rootDir = ".."
+# to point back at the package root. The validator must accept this since the
+# resolved path stays inside the package.
+ts_project(
+    name = "subfolder_tsconfig",
+    srcs = ["subdir/a.ts"],
+    out_dir = "subfolder_out",
+    tsconfig = "subdir/tsconfig-parent.json",
+)
+
+build_test(
+    name = "subfolder_tsconfig_test",
+    targets = [":subfolder_tsconfig"],
 )

--- a/examples/root_dir/subdir/tsconfig-parent.json
+++ b/examples/root_dir/subdir/tsconfig-parent.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "rootDir": ".."
+    },
+    "exclude": []
+}

--- a/ts/private/ts_project_options_validator.cjs
+++ b/ts/private/ts_project_options_validator.cjs
@@ -148,10 +148,10 @@ function main(_a) {
         var optionVal = options[optionName]
         if (typeof optionVal !== 'string' || !optionVal) return
 
-        // tsconfigPath is relative, so options[optionName] stays in the same
-        // relative form. copy_file_to_bin_action enforces tsconfig-in-package.
-        var tsconfigDir = path_1.dirname(tsconfigPath)
-        var rel = path_1.relative(tsconfigDir, optionVal)
+        // The boundary is the rule's package, not the tsconfig's directory:
+        // tsconfigs may live in subfolders (e.g. pkg/config/tsconfig.json) where
+        // ".." still resolves inside the package.
+        var rel = path_1.relative(packageDir, optionVal)
 
         if (rel === '..' || rel.startsWith('../') || rel.startsWith('..\\')) {
             throw new Error(

--- a/ts/private/ts_project_options_validator.cjs
+++ b/ts/private/ts_project_options_validator.cjs
@@ -144,6 +144,35 @@ function main(_a) {
             )
         }
     }
+    function checkDirInParent(optionName, attrName) {
+        var optionVal = options[optionName]
+        if (typeof optionVal !== 'string' || !optionVal) return
+
+        // tsconfigPath is relative, so options[optionName] stays in the same
+        // relative form. copy_file_to_bin_action enforces tsconfig-in-package.
+        var tsconfigDir = path_1.dirname(tsconfigPath)
+        var rel = path_1.relative(tsconfigDir, optionVal)
+
+        if (rel === '..' || rel.startsWith('../') || rel.startsWith('..\\')) {
+            throw new Error(
+                '\n\nThe ' +
+                    optionName +
+                    ' in the tsconfig resolves to "' +
+                    optionVal +
+                    '"' +
+                    ' which is a parent of the package directory.\n\n' +
+                    'This is not supported by ts_project because all output files must be within\n' +
+                    'the package output directory.\n\n' +
+                    'If your tsconfig is shared from a parent directory, set ' +
+                    optionName +
+                    ' in that\n' +
+                    'tsconfig to a path at or below the package, or use the ' +
+                    attrName +
+                    ' attribute\n' +
+                    'on ts_project to override it.\n'
+            )
+        }
+    }
     var jsxEmit =
         ((_b = {}),
         (_b[ts.JsxEmit.None] = 'none'),
@@ -205,6 +234,9 @@ function main(_a) {
     check('declaration')
     check('incremental')
     check('tsBuildInfoFile', 'ts_build_info_file')
+    // Must run before check_out_dir to win over its less specific attr-mismatch error.
+    checkDirInParent('rootDir', 'root_dir')
+    checkDirInParent('outDir', 'out_dir')
     check_out_dir('outDir', 'out_dir')
     check_out_dir('declarationDir', 'declaration_dir')
     check_out_dir('rootDir', 'root_dir')

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -1,6 +1,7 @@
 "Helper rule to check that ts_project attributes match tsconfig.json properties"
 
 load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
+load(":ts_lib.bzl", _lib = "lib")
 
 def _validate_action(ctx, tsconfig, tsconfig_deps):
     """Create an action to validate the ts_project attributes against the tsconfig.json properties.
@@ -33,7 +34,7 @@ Assumes all tsconfig file deps are already copied to the bin directory.
         to_output_relative_path(tsconfig),
         to_output_relative_path(marker),
         str(ctx.label),
-        ctx.label.package,
+        _lib.join(ctx.label.workspace_root, ctx.label.package),
         json.encode(config),
     ])
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Validate `rootDir` and `outDir` will work with bazel

### Test plan

- Covered by existing test cases
- New test cases added
