### PR TITLE
fix: omit `buildinfo_out` when `transpiler` and `declaration_transpiler` are used

### DIFF
--- a/examples/transpiler/BUILD.bazel
+++ b/examples/transpiler/BUILD.bazel
@@ -349,3 +349,38 @@ assert_outputs(
         "transpiler/build-declarations_custom/a.js.map",
     ],
 )
+
+# custom js & dts transpilers (composite = true)
+ts_project(
+    name = "custom_transpilers_composite",
+    srcs = ["a.ts"],
+    composite = True,
+    declaration = True,
+    declaration_transpiler = partial.make(
+        tsc_dts,
+        out_dir = "build-custom_transpilers_composite",
+    ),
+    out_dir = "build-custom_transpilers_composite",
+    source_map = True,
+    transpiler = partial.make(
+        tsc_js,
+        out_dir = "build-custom_transpilers_composite",
+    ),
+    tsconfig = {
+        "compilerOptions": {
+            "composite": True,
+        },
+    },
+)
+
+build_test(
+    name = "custom_transpilers_composite_test",
+    targets = [
+        ":custom_transpilers_composite",
+        ":custom_transpilers_composite_types",
+        ":custom_transpilers_composite_typecheck",
+        ":custom_transpilers_composite_typecheck_test",
+        "build-custom_transpilers_composite/a.js",
+        "build-custom_transpilers_composite/a.d.ts",
+    ],
+)

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -490,7 +490,7 @@ def ts_project(
         map_outs = tsc_map_outs,
         typings_outs = tsc_typings_outs,
         typing_maps_outs = tsc_typing_maps_outs,
-        buildinfo_out = tsbuildinfo_path if composite or incremental else None,
+        buildinfo_out = tsbuildinfo_path if (composite or incremental) and (emit_tsc_js or emit_tsc_dts) else None,
         no_emit = no_emit,
         emit_declaration_only = emit_declaration_only,
         tsc = tsc,


### PR DESCRIPTION
Handle an edge case where a `.tsbuildinfo` file is expected but `tsc` is never used to emit anything.

Full repro here: https://github.com/walkerburgin/tsbuildinfo-repro

```
➜  tsbuildinfo-repro git:(master) ✗ bazel build //...
ERROR: /Users/wburgin/Repositories/walkerburgin/tsbuildinfo-repro/pkgs/bar-lib/BUILD:23:11: in ts_project rule //pkgs/bar-lib:bar-lib:
/Users/wburgin/Library/Caches/bazel/_bazel_wburgin/4ff382b5dbb2348818e8d30483df60bb/external/aspect_rules_ts+/ts/private/ts_project.bzl:70:5: The following files have no generating action:
pkgs/bar-lib/bar-lib.tsbuildinfo
ERROR: /Users/wburgin/Repositories/walkerburgin/tsbuildinfo-repro/pkgs/bar-lib/BUILD:23:11: Analysis of target '//pkgs/bar-lib:bar-lib' (config: ab1598d) failed
ERROR: Analysis of target '//pkgs/bar-lib:bar-lib_typecheck' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.476s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
```

We have `composite` projects for IDE support, use `swc` for transpilation, and are looking at using `tsgo` (or maybe OXC) for `.d.ts` transpilation.

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes
  
> Handle an edge case where a `.tsbuildinfo` file is expected but `tsc` is never used to emit anything.

### Test plan

- Added a new test case
- Manual testing; please provide instructions so we can reproduce:

See https://github.com/walkerburgin/tsbuildinfo-repro
