### PR TITLE
Add package_json parameter to ts_config and expose rule to exclude it

### DIFF
--- a/examples/package_json_usage/colocated/BUILD.bazel
+++ b/examples/package_json_usage/colocated/BUILD.bazel
@@ -10,7 +10,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
-    deps = ["package.json"],
+    package_json = "package.json",
 )
 
 ts_project(

--- a/examples/package_json_usage/imports_field/BUILD.bazel
+++ b/examples/package_json_usage/imports_field/BUILD.bazel
@@ -9,7 +9,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 ts_config(
     name = "tsconfig",
     src = "//package_json_usage:tsconfig",
-    deps = ["package.json"],
+    package_json = "package.json",
 )
 
 ts_project(

--- a/examples/package_json_usage/parent_src/BUILD.bazel
+++ b/examples/package_json_usage/parent_src/BUILD.bazel
@@ -6,7 +6,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 ts_config(
     name = "tsconfig",
     src = "//package_json_usage:tsconfig",
-    deps = ["package.json"],
+    package_json = "package.json",
 )
 
 ts_project(

--- a/examples/package_json_usage/self_reference/BUILD.bazel
+++ b/examples/package_json_usage/self_reference/BUILD.bazel
@@ -9,7 +9,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 ts_config(
     name = "tsconfig",
     src = "//package_json_usage:tsconfig",
-    deps = ["package.json"],
+    package_json = "package.json",
 )
 
 ts_project(

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -8,11 +8,12 @@ load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("//ts/private:build_test.bzl", "build_test")
-load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")
+load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config", _ts_config_rule = "ts_config_rule")
 load("//ts/private:ts_lib.bzl", _lib = "lib")
 load("//ts/private:ts_project.bzl", _ts_project = "ts_project")
 
 ts_config = _ts_config
+ts_config_rule = _ts_config_rule
 TsConfigInfo = _TsConfigInfo
 ts_project_rule = _ts_project
 

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -90,7 +90,7 @@ def _ts_config_impl(ctx):
         TsConfigInfo(deps = depset(files, transitive = transitive_deps)),
     ]
 
-ts_config = rule(
+ts_config_rule = rule(
     implementation = _ts_config_impl,
     attrs = {
         "deps": attr.label_list(
@@ -112,6 +112,45 @@ extended configuration file as well, to pass them both to the TypeScript compile
 """,
     toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
 )
+
+def ts_config(name, src, deps = [], package_json = None, **kwargs):
+    """Wrapper around ts_config_rule that optionally includes a package.json.
+
+    When package_json is set, an additional `name + "_without_package_json"` target
+    is created so that extending ts_configs can inherit the tsconfig without
+    receiving the package.json.
+
+    Args:
+        name: name of the resulting write_file rule
+        config: tsconfig dictionary
+        files: list of input .ts files to put in the files[] array
+        out: the file to write
+        extends: a label for a tsconfig.json file to extend from, if any
+        allow_js: value of the allowJs tsconfig property
+        resolve_json_module: value of the resolveJsonModule tsconfig property
+        package_json: a package.json file to include in deps
+        **kwargs: Other common named parameters such as `tags` or `visibility`
+    """
+    if package_json:
+        ts_config_rule(
+            name = name,
+            src = src,
+            deps = deps + [package_json],
+            **kwargs
+        )
+        ts_config_rule(
+            name = name + "_without_package_json",
+            src = src,
+            deps = deps,
+            **kwargs
+        )
+    else:
+        ts_config_rule(
+            name = name,
+            src = src,
+            deps = deps,
+            **kwargs
+        )
 
 def _write_tsconfig_rule(ctx):
     # TODO: is it useful to expand Make variables in the content?

--- a/ts/test/ts_config_test.bzl
+++ b/ts/test/ts_config_test.bzl
@@ -75,7 +75,7 @@ def ts_config_test_suite(name):
     ts_config(
         name = "tsconfig_with_package_json_dep",
         src = "src_tsconfig_pkgjson.json",
-        deps = [":src_package_json"],
+        package_json = ":src_package_json",
     )
     ts_project(
         name = "use_tsconfig_with_package_json_dep",
@@ -83,6 +83,27 @@ def ts_config_test_suite(name):
         declaration = True,
         out_dir = "pkgjson-outdir",
         tsconfig = ":tsconfig_with_package_json_dep",
+    )
+
+    # The _without_package_json companion target created by ts_config's
+    # package_json parameter — should NOT propagate the package.json.
+    write_file(
+        name = "src_tsconfig_nopkg",
+        out = "src_tsconfig_nopkg.json",
+        content = ["""{"compilerOptions": {"declaration": true, "outDir": "nopkg-outdir"}}"""],
+        tags = ["manual"],
+    )
+    ts_config(
+        name = "tsconfig_nopkg",
+        src = "src_tsconfig_nopkg.json",
+        package_json = ":src_package_json",
+    )
+    ts_project(
+        name = "use_tsconfig_without_package_json",
+        srcs = [":src_ts"],
+        declaration = True,
+        out_dir = "nopkg-outdir",
+        tsconfig = ":tsconfig_nopkg_without_package_json",
     )
 
     # ts_config whose src is another ts_config target (mirrors the
@@ -102,7 +123,7 @@ def ts_config_test_suite(name):
     ts_config(
         name = "tsconfig_wrapping_ts_config",
         src = ":tsconfig_wrap_parent",
-        deps = [":src_package_json"],
+        package_json = ":src_package_json",
     )
     ts_project(
         name = "use_tsconfig_wrapping_ts_config",
@@ -185,6 +206,11 @@ def ts_config_test_suite(name):
         target_under_test = "use_tsconfig_wrapping_ts_config",
     )
 
+    _ts_project_does_not_see_package_json_test(
+        name = "tsconfig_without_package_json_test",
+        target_under_test = "use_tsconfig_without_package_json",
+    )
+
     native.test_suite(
         name = name,
         tests = [
@@ -195,6 +221,7 @@ def ts_config_test_suite(name):
             ":outputs_use_dict_extending_tsconfig_target_test",
             ":tsconfig_with_package_json_dep_test",
             ":tsconfig_wrapping_ts_config_test",
+            ":tsconfig_without_package_json_test",
         ],
     )
 
@@ -257,3 +284,22 @@ def _ts_project_sees_package_json_in_tsc_inputs_test_impl(ctx):
     return analysistest.end(env)
 
 _ts_project_sees_package_json_in_tsc_inputs_test = analysistest.make(_ts_project_sees_package_json_in_tsc_inputs_test_impl)
+
+def _ts_project_does_not_see_package_json_test_impl(ctx):
+    """Asserts that the _without_package_json companion target does not
+    propagate a package.json to the tsc action inputs."""
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    action_input_paths = [f.path for f in target_under_test[OutputGroupInfo]._action_inputs.to_list()]
+    package_json_inputs = [p for p in action_input_paths if p.endswith("/package.json")]
+    asserts.equals(
+        env,
+        0,
+        len(package_json_inputs),
+        "expected no package.json in tsc action inputs for the _without_package_json target, got: {}".format(package_json_inputs),
+    )
+
+    return analysistest.end(env)
+
+_ts_project_does_not_see_package_json_test = analysistest.make(_ts_project_does_not_see_package_json_test_impl)


### PR DESCRIPTION
Adds a `packge_json` field to `ts_config` so `package.json` files can be optionally included in follow up configs.

This allows ts_config rules to include package.json files, which are required for some ts functionalities, while also allowing downstream packages to consume the ts_config without also having their cache invalidated by package.json changes

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
