### PR TITLE
fix: enforce ts_project(deps) JsInfo requirement

### DIFF
--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -1,5 +1,7 @@
 "Utilities functions for selecting and filtering ts and other files"
 
+load("@aspect_rules_js//js:providers.bzl", "JsInfo")
+
 # Attributes common to all TypeScript rules
 STD_ATTRS = {
     "assets": attr.label_list(
@@ -29,6 +31,7 @@ https://docs.aspect.build/rulesets/aspect_rules_js/docs/js_library#data for more
 Follows the same runfiles semantics as `js_library` `deps` attribute. See
 https://docs.aspect.build/rulesets/aspect_rules_js/docs/js_library#deps for more info.
 """,
+        providers = [JsInfo],  # Same as js_library(deps)
     ),
     "out_dir": attr.string(
         doc = "https://www.typescriptlang.org/tsconfig#outDir",


### PR DESCRIPTION
This was for some reason [removed in 2.0](https://github.com/aspect-build/rules_ts/pull/593/changes?diff=split&w=0#diff-2194ca76c259ab63d7fa66a7c5f87b12969e16ad572cbfae754844cc4195ac5eL27) while still documenting that it should align with `js_library(deps)`.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`ts_project(deps)` now correctly enforces the requirement that targets provide `JsInfo`

### Test plan

- Covered by existing test cases
