### PR TITLE
feat: support TypeScript 7 RC

### DIFF
--- a/e2e/external_dep/BUILD
+++ b/e2e/external_dep/BUILD
@@ -30,12 +30,21 @@ ts_project(
     tsc = "@npm_typescript-56rc//:tsc",
 )
 
+ts_project(
+    name = "lib.ts7rc",
+    srcs = ["lib.ts"],
+    composite = True,
+    out_dir = "ts7rc_out",
+    tsc = "@npm_typescript-7rc//:tsc",
+)
+
 build_test(
     name = "test",
     targets = [
         ":lib",
         "lib.ts3",
         "lib.ts56rc",
+        "lib.ts7rc",
     ],
 )
 

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -25,7 +25,13 @@ rules_ts_ext.deps(
     ts_integrity = "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
     ts_version = "5.6.1-rc",
 )
-use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript3")
+
+# Example of a native rc version
+rules_ts_ext.deps(
+    name = "npm_typescript-7rc",
+    ts_version = "7.0.1-rc",
+)
+use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript-7rc", "npm_typescript3")
 
 bazel_dep(name = "sub_external", version = "0.0.0", dev_dependency = True)
 local_path_override(

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -18,6 +18,11 @@ rules_ts_dependencies(
     ts_version = "5.6.1-rc",
 )
 
+rules_ts_dependencies(
+    name = "npm_typescript-7rc",
+    ts_version = "7.0.1-rc",
+)
+
 # NOTE: only required on non-bzlmod where the sub_external/WORKSPACE is not loaded to declare npm_typescript2
 rules_ts_dependencies(
     name = "npm_typescript2",

--- a/ts/BUILD.typescript
+++ b/ts/BUILD.typescript
@@ -1,12 +1,12 @@
 "BUILD file inserted into @npm_typescript repository"
 
-load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("@aspect_rules_js//npm/private:npm_package_internal.bzl", "npm_package_internal")
-load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+load("@aspect_rules_js//npm/private:npm_package_internal.bzl", "npm_package_internal")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
 
 bool_setting(
     name = "is_typescript_5_or_greater_flag",
@@ -35,6 +35,13 @@ npm_link_package(
     visibility = ["//visibility:public"],
 )
 
+# ts_native_package_targets
+
+TSC_DATA = [
+    ":node_modules/typescript",
+    # ts_native_package_labels
+]
+
 # tsc
 directory_path(
     name = "tsc_entrypoint",
@@ -45,7 +52,7 @@ directory_path(
 
 js_binary(
     name = "tsc",
-    data = [":node_modules/typescript"],
+    data = TSC_DATA,
     entry_point = ":tsc_entrypoint",
     visibility = ["//visibility:public"],
 )
@@ -59,7 +66,7 @@ copy_file(
 
 js_binary(
     name = "validator",
-    data = [":node_modules/typescript"],
+    data = TSC_DATA,
     entry_point = "copy_validator",
     visibility = ["//visibility:public"],
 )
@@ -87,9 +94,8 @@ js_binary(
     name = "tsc_worker",
     data = [
         ":copy_worker_js",
-        ":node_modules/typescript",
         ":package_json",
-    ],
+    ] + TSC_DATA,
     entry_point = "copy_ts_project_worker",
     visibility = ["//visibility:public"],
 )

--- a/ts/private/mirror_versions.sh
+++ b/ts/private/mirror_versions.sh
@@ -2,7 +2,7 @@
 set -o nounset -o errexit -o pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-JQ_FILTER='
+TOOL_VERSIONS_JQ_FILTER='
 [
     .versions[]
     | select(.version | test("^[0-9.]+$"))
@@ -10,9 +10,40 @@ JQ_FILTER='
 ] | from_entries
 '
 
+REGISTRY_JSON=$(mktemp)
 NEW=$(mktemp)
-sed '/TOOL_VERSIONS =/Q' $SCRIPT_DIR/versions.bzl >$NEW
-echo -n "TOOL_VERSIONS = " >>$NEW
-curl --silent https://registry.npmjs.org/typescript | jq "$JQ_FILTER" >>$NEW
+trap 'rm -f "$REGISTRY_JSON" "$NEW"' EXIT
 
-cp $NEW $SCRIPT_DIR/versions.bzl
+curl --silent https://registry.npmjs.org/typescript >"$REGISTRY_JSON"
+
+awk '/NATIVE_TYPESCRIPT_VERSIONS =/ { exit } { print }' "$SCRIPT_DIR/versions.bzl" >"$NEW"
+
+RC_VERSION=$(jq -r '."dist-tags".rc // empty' "$REGISTRY_JSON")
+echo "NATIVE_TYPESCRIPT_VERSIONS = {" >>"$NEW"
+if [[ -n "$RC_VERSION" ]]; then
+	echo "    \"$RC_VERSION\": {" >>"$NEW"
+	rc_integrity=$(jq -r --arg rc "$RC_VERSION" '.versions[] | select(.version == $rc) | .dist.integrity' "$REGISTRY_JSON")
+	echo "        \"integrity\": \"$rc_integrity\"," >>"$NEW"
+	echo "        \"native_package_integrities\": {" >>"$NEW"
+	jq -r --arg rc "$RC_VERSION" '
+        .versions[]
+        | select(.version == $rc)
+        | (.optionalDependencies // {})
+        | keys[]
+        | select(startswith("@typescript/"))
+    ' "$REGISTRY_JSON" | while read -r package_name; do
+		native_package="${package_name#@typescript/}"
+		package_url_name="${package_name/\//%2f}"
+		integrity=$(curl --silent "https://registry.npmjs.org/${package_url_name}/${RC_VERSION}" | jq -r '.dist.integrity')
+		echo "            \"$native_package\": \"$integrity\"," >>"$NEW"
+	done
+	echo "        }," >>"$NEW"
+	echo "    }," >>"$NEW"
+fi
+echo "}" >>"$NEW"
+echo "" >>"$NEW"
+
+echo -n "TOOL_VERSIONS = " >>"$NEW"
+jq "$TOOL_VERSIONS_JQ_FILTER" "$REGISTRY_JSON" >>"$NEW"
+
+cp "$NEW" "$SCRIPT_DIR/versions.bzl"

--- a/ts/private/npm_repositories.bzl
+++ b/ts/private/npm_repositories.bzl
@@ -1,7 +1,9 @@
 """Runtime dependencies fetched from npm"""
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//ts/private:versions.bzl", "TOOL_VERSIONS")
+load("//ts/private:versions.bzl", "NATIVE_TYPESCRIPT_VERSIONS", "TOOL_VERSIONS")
+
+_TYPESCRIPT_NATIVE_PACKAGE_PREFIX = "@typescript/"
 
 def _http_archive_version_impl(rctx):
     integrity = None
@@ -23,12 +25,15 @@ def _http_archive_version_impl(rctx):
             fail("key 'typescript' not found in either dependencies or devDependencies of %s" % json_path)
         version = ts
 
+    native_typescript_version = NATIVE_TYPESCRIPT_VERSIONS.get(version, {})
     if integrity:
         pass
     elif rctx.attr.integrity:
         integrity = rctx.attr.integrity
     elif version in TOOL_VERSIONS.keys():
         integrity = TOOL_VERSIONS[version]
+    elif native_typescript_version:
+        integrity = native_typescript_version["integrity"]
     else:
         fail("""typescript version {} is not mirrored in rules_ts, is this a real version?
             If so, you must manually set 'ts_integrity'.
@@ -45,12 +50,51 @@ def _http_archive_version_impl(rctx):
         # to update the integrity but the `ts_version` is already different.
         canonical_id = get_default_canonical_id(rctx, urls),
     )
+
+    native_package_integrities = native_typescript_version.get("native_package_integrities", {})
+    native_packages = _declared_native_packages(rctx)
+    missing_native_packages = []
+    for native_package in native_packages:
+        if native_package not in native_package_integrities:
+            missing_native_packages.append(native_package)
+    if missing_native_packages:
+        fail("""typescript version {} requires native packages that are not mirrored in rules_ts: {}
+            See documentation on rules_ts_dependencies.""".format(version, ", ".join(missing_native_packages)))
+
+    native_package_labels = []
+    native_package_targets = []
+    for native_package in sorted(native_packages):
+        _download_native_package(rctx, version, native_package, native_package_integrities[native_package])
+        target_name = "npm_{}".format(native_package.replace("-", "_"))
+        link_name = "node_modules/@typescript/{}".format(native_package)
+        native_package_targets.append("""npm_package_internal(
+    name = "{target_name}",
+    src = "native_packages/{native_package}/package",
+    package = "@typescript/{native_package}",
+    version = "{version}",
+)
+
+npm_link_package(
+    name = "{link_name}",
+    src = ":{target_name}",
+    visibility = ["//visibility:public"],
+)
+""".format(
+            link_name = link_name,
+            native_package = native_package,
+            target_name = target_name,
+            version = version,
+        ))
+        native_package_labels.append('    ":{link_name}",\n'.format(link_name = link_name))
+
     build_file_substitutions = {
         "ts_version": version,
         # Note: we can't depend on bazel_skylib because this code is called from
         # rules_ts_dependencies so it's not "in scope" yet.
         # So we can't use versions.bzl to parse the version
         "is_ts_5": str(int(version.split(".")[0]) >= 5),
+        "# ts_native_package_labels": "".join(native_package_labels),
+        "# ts_native_package_targets": "\n".join(native_package_targets),
     }
     rctx.template(
         "BUILD.bazel",
@@ -64,6 +108,27 @@ def _http_archive_version_impl(rctx):
         return None
 
     return rctx.repo_metadata(reproducible = True)
+
+def _declared_native_packages(rctx):
+    package_json = json.decode(rctx.read(rctx.path("package/package.json")))
+    optional_dependencies = package_json.get("optionalDependencies", {})
+    native_packages = []
+    for package_name in optional_dependencies.keys():
+        if package_name.startswith(_TYPESCRIPT_NATIVE_PACKAGE_PREFIX):
+            native_packages.append(package_name[len(_TYPESCRIPT_NATIVE_PACKAGE_PREFIX):])
+    return native_packages
+
+def _download_native_package(rctx, version, native_package, integrity):
+    urls = ["https://registry.npmjs.org/@typescript/{native_package}/-/{native_package}-{version}.tgz".format(
+        native_package = native_package,
+        version = version,
+    )]
+    rctx.download_and_extract(
+        url = urls,
+        output = "native_packages/{}".format(native_package),
+        integrity = integrity,
+        canonical_id = get_default_canonical_id(rctx, urls),
+    )
 
 http_archive_version = repository_rule(
     doc = "Re-implementation of http_archive that can read the version from package.json",

--- a/ts/private/npm_repositories.bzl
+++ b/ts/private/npm_repositories.bzl
@@ -51,12 +51,43 @@ def _http_archive_version_impl(rctx):
         canonical_id = get_default_canonical_id(rctx, urls),
     )
 
+    # Only inspect and link the platform-specific native packages for versions
+    # in NATIVE_TYPESCRIPT_VERSIONS.
+    native_package_labels = []
+    native_package_targets = []
+    if native_typescript_version:
+        native_package_labels, native_package_targets = _link_native_packages(rctx, version, native_typescript_version)
+
+    build_file_substitutions = {
+        "ts_version": version,
+        # Note: we can't depend on bazel_skylib because this code is called from
+        # rules_ts_dependencies so it's not "in scope" yet.
+        # So we can't use versions.bzl to parse the version
+        "is_ts_5": str(int(version.split(".")[0]) >= 5),
+        "# ts_native_package_labels": "".join(native_package_labels),
+        "# ts_native_package_targets": "\n".join(native_package_targets),
+    }
+    rctx.template(
+        "BUILD.bazel",
+        rctx.path(rctx.attr._build_file),
+        substitutions = build_file_substitutions,
+        executable = False,
+    )
+
+    # Bazel <8.3.0 lacks rctx.repo_metadata
+    if not hasattr(rctx, "repo_metadata"):
+        return None
+
+    return rctx.repo_metadata(reproducible = True)
+
+def _link_native_packages(rctx, version, native_typescript_version):
     native_package_integrities = native_typescript_version.get("native_package_integrities", {})
     native_packages = _declared_native_packages(rctx)
-    missing_native_packages = []
-    for native_package in native_packages:
-        if native_package not in native_package_integrities:
-            missing_native_packages.append(native_package)
+    missing_native_packages = [
+        native_package
+        for native_package in native_packages
+        if native_package not in native_package_integrities
+    ]
     if missing_native_packages:
         fail("""typescript version {} requires native packages that are not mirrored in rules_ts: {}
             See documentation on rules_ts_dependencies.""".format(version, ", ".join(missing_native_packages)))
@@ -87,27 +118,7 @@ npm_link_package(
         ))
         native_package_labels.append('    ":{link_name}",\n'.format(link_name = link_name))
 
-    build_file_substitutions = {
-        "ts_version": version,
-        # Note: we can't depend on bazel_skylib because this code is called from
-        # rules_ts_dependencies so it's not "in scope" yet.
-        # So we can't use versions.bzl to parse the version
-        "is_ts_5": str(int(version.split(".")[0]) >= 5),
-        "# ts_native_package_labels": "".join(native_package_labels),
-        "# ts_native_package_targets": "\n".join(native_package_targets),
-    }
-    rctx.template(
-        "BUILD.bazel",
-        rctx.path(rctx.attr._build_file),
-        substitutions = build_file_substitutions,
-        executable = False,
-    )
-
-    # Bazel <8.3.0 lacks rctx.repo_metadata
-    if not hasattr(rctx, "repo_metadata"):
-        return None
-
-    return rctx.repo_metadata(reproducible = True)
+    return native_package_labels, native_package_targets
 
 def _declared_native_packages(rctx):
     package_json = json.decode(rctx.read(rctx.path("package/package.json")))

--- a/ts/private/versions.bzl
+++ b/ts/private/versions.bzl
@@ -7,7 +7,34 @@ Automatically mirrored using mirror_versions.sh and automated on GitHub Actions
 # Note: this requires a newer git version, 2.25.1 is too old, but GHA runs with 2.41.0 as of Sep 2023
 RULES_TS_VERSION = "$Format:%(describe:tags=true)$"
 
-# Note: Versions should be ascending order so TOOL_VERSIONS.keys()[-1] is the latest version.
+NATIVE_TYPESCRIPT_VERSIONS = {
+    "7.0.1-rc": {
+        "integrity": "sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==",
+        "native_package_integrities": {
+            "typescript-aix-ppc64": "sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==",
+            "typescript-darwin-arm64": "sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==",
+            "typescript-darwin-x64": "sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==",
+            "typescript-freebsd-arm64": "sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==",
+            "typescript-freebsd-x64": "sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==",
+            "typescript-linux-arm": "sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==",
+            "typescript-linux-arm64": "sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==",
+            "typescript-linux-loong64": "sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==",
+            "typescript-linux-mips64el": "sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==",
+            "typescript-linux-ppc64": "sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==",
+            "typescript-linux-riscv64": "sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==",
+            "typescript-linux-s390x": "sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==",
+            "typescript-linux-x64": "sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==",
+            "typescript-netbsd-arm64": "sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==",
+            "typescript-netbsd-x64": "sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==",
+            "typescript-openbsd-arm64": "sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==",
+            "typescript-openbsd-x64": "sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==",
+            "typescript-sunos-x64": "sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==",
+            "typescript-win32-arm64": "sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==",
+            "typescript-win32-x64": "sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==",
+        },
+    },
+}
+
 TOOL_VERSIONS = {
     "0.8.0": "sha512-t4DYxzL6Gt3+TRuJXtmh+3KfcY5iSM8J4lzUgfQkTOr78xFbmor79x/dQEGMaiqO2HJBbFGO3RlIaxPzpP5JMA==",
     "0.8.1": "sha512-/cfem275IES0o4/zVD1UmXfE3k5j2OAianSI2Oa1gYzWhAJ44OjNlXv3LVIj5EZ0fgks/XBtzp8aXVsaYILTVg==",


### PR DESCRIPTION
Summary
- handle native TypeScript versions that ship platform-specific triple packages like @typescript/typescript-darwin-arm64
- keep native TS prerelease metadata separate from TOOL_VERSIONS so LATEST_TYPESCRIPT_VERSION stays stable-only
- link TS 7 native packages into the generated npm repo
- add the TS 7 RC fixture alongside the existing 5.6 RC fixture in bzlmod and WORKSPACE

Platform note
- locally tested on macOS darwin-arm64
- CI should exercise Linux x64 for e2e/external_dep via the Aspect Workflows matrix
- existing CI does not run this e2e workspace on Windows

Test plan
- ./ts/private/mirror_versions.sh
- buildifier ts/private/versions.bzl ts/private/npm_repositories.bzl ts/repositories.bzl ts/BUILD.typescript e2e/external_dep/MODULE.bazel e2e/external_dep/WORKSPACE e2e/external_dep/BUILD
- bazel test //... (from e2e/external_dep)
- bazel test --enable_bzlmod=false //... (from e2e/external_dep)
- bazel test //ts/...