### PR TITLE
chore: move buildifier invocation for versions.bzl to mirror_versions.sh

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,12 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
-            - run: |
-                  ./ts/private/mirror_versions.sh
-                  npx @bazel/buildifier ts/private/versions.bzl
+            - run: ./ts/private/mirror_versions.sh
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
               with:
                   commit-message: 'fix: add latest ts external release hashes'
-                  author: "aspect-marvin <marvin@aspect.build>"
-                  committer: "aspect-marvin <marvin@aspect.build>"
+                  author: 'aspect-marvin <marvin@aspect.build>'
+                  committer: 'aspect-marvin <marvin@aspect.build>'

--- a/ts/private/mirror_versions.sh
+++ b/ts/private/mirror_versions.sh
@@ -47,3 +47,7 @@ echo -n "TOOL_VERSIONS = " >>"$NEW"
 jq "$TOOL_VERSIONS_JQ_FILTER" "$REGISTRY_JSON" >>"$NEW"
 
 cp "$NEW" "$SCRIPT_DIR/versions.bzl"
+
+# jq emits 2-space indentation; reformat to the repo's buildifier style so the
+# generated file is committable as-is without a separate manual step.
+npx @bazel/buildifier "$SCRIPT_DIR/versions.bzl"


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
