### PR TITLE
chore: only include ts7 in the NATIVE_TYPESCRIPT_VERSIONS block, support non-rc versions

### DIFF
--- a/ts/private/mirror_versions.sh
+++ b/ts/private/mirror_versions.sh
@@ -2,45 +2,92 @@
 set -o nounset -o errexit -o pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
+# Stable v6 and below only: v7+ lives in NATIVE_TYPESCRIPT_VERSIONS instead so
+# LATEST_TYPESCRIPT_VERSION (TOOL_VERSIONS.keys()[-1], the default ts_version)
+# does not silently switch to the native compiler.
 TOOL_VERSIONS_JQ_FILTER='
 [
     .versions[]
-    | select(.version | test("^[0-9.]+$"))
+    | select((.version | test("^[0-9.]+$")) and ((.version | split(".")[0] | tonumber) < 7))
     | {key: .version, value: .dist.integrity}
 ] | from_entries
 '
 
+# Versions shipping the native (tsgo) compiler: every stable v7+ version, plus
+# the current rc dist-tag (if any), plus every version already mirrored in
+# versions.bzl. These are kept out of TOOL_VERSIONS and need the integrity of
+# each platform-specific @typescript/typescript-* package.
+#
+# Prereleases persist after the rc dist-tag moves on; delete an entry from
+# versions.bzl to retire it (like rules_nodejs node versions).
+NATIVE_VERSIONS_JQ_SELECT='
+    select(
+        ((.version | test("^[0-9.]+$")) and ((.version | split(".")[0] | tonumber) >= 7))
+        or .version == $rc
+        or IN(.version; $existing[])
+    )
+'
+
+NATIVE_VERSIONS_JQ_FILTER='
+[
+    .versions[]
+    | '"$NATIVE_VERSIONS_JQ_SELECT"'
+    | .version as $version
+    | {
+        key: $version,
+        value: {
+            integrity: .dist.integrity,
+            native_package_integrities: ([
+                (.optionalDependencies // {})
+                | keys[]
+                | select(startswith("@typescript/"))
+                | {
+                    key: sub("^@typescript/"; ""),
+                    value: ($platforms[0][.][$version] // error("no mirrored integrity for \(.)@\($version)")),
+                }
+            ] | from_entries),
+        },
+    }
+] | from_entries
+'
+
 REGISTRY_JSON=$(mktemp)
+PLATFORMS_JSON=$(mktemp)
 NEW=$(mktemp)
-trap 'rm -f "$REGISTRY_JSON" "$NEW"' EXIT
+trap 'rm -f "$REGISTRY_JSON" "$PLATFORMS_JSON" "$NEW"' EXIT
 
 curl --silent https://registry.npmjs.org/typescript >"$REGISTRY_JSON"
 
-awk '/NATIVE_TYPESCRIPT_VERSIONS =/ { exit } { print }' "$SCRIPT_DIR/versions.bzl" >"$NEW"
-
 RC_VERSION=$(jq -r '."dist-tags".rc // empty' "$REGISTRY_JSON")
-echo "NATIVE_TYPESCRIPT_VERSIONS = {" >>"$NEW"
-if [[ -n "$RC_VERSION" ]]; then
-	echo "    \"$RC_VERSION\": {" >>"$NEW"
-	rc_integrity=$(jq -r --arg rc "$RC_VERSION" '.versions[] | select(.version == $rc) | .dist.integrity' "$REGISTRY_JSON")
-	echo "        \"integrity\": \"$rc_integrity\"," >>"$NEW"
-	echo "        \"native_package_integrities\": {" >>"$NEW"
-	jq -r --arg rc "$RC_VERSION" '
+
+# Version keys already mirrored in versions.bzl, as a JSON array. Top-level
+# keys are indented 4 spaces; nested package keys are indented further.
+EXISTING_NATIVE_VERSIONS=$(
+	awk '/^NATIVE_TYPESCRIPT_VERSIONS = {/,/^}/' "$SCRIPT_DIR/versions.bzl" |
+		sed -n 's/^    "\([^"]*\)": {$/\1/p' |
+		jq --raw-input --null-input '[inputs]'
+)
+
+# Fetch each platform-specific package used by any native version once,
+# reducing its registry metadata to {package: {version: integrity}}.
+jq -r --arg rc "$RC_VERSION" --argjson existing "$EXISTING_NATIVE_VERSIONS" '
+    [
         .versions[]
-        | select(.version == $rc)
+        | '"$NATIVE_VERSIONS_JQ_SELECT"'
         | (.optionalDependencies // {})
         | keys[]
         | select(startswith("@typescript/"))
-    ' "$REGISTRY_JSON" | while read -r package_name; do
-		native_package="${package_name#@typescript/}"
-		package_url_name="${package_name/\//%2f}"
-		integrity=$(curl --silent "https://registry.npmjs.org/${package_url_name}/${RC_VERSION}" | jq -r '.dist.integrity')
-		echo "            \"$native_package\": \"$integrity\"," >>"$NEW"
-	done
-	echo "        }," >>"$NEW"
-	echo "    }," >>"$NEW"
-fi
-echo "}" >>"$NEW"
+    ]
+    | unique | .[]
+' "$REGISTRY_JSON" | while read -r package_name; do
+	curl --silent "https://registry.npmjs.org/${package_name/\//%2f}" |
+		jq '{(.name): (.versions | map_values(.dist.integrity))}'
+done | jq --slurp 'add // {}' >"$PLATFORMS_JSON"
+
+awk '/NATIVE_TYPESCRIPT_VERSIONS =/ { exit } { print }' "$SCRIPT_DIR/versions.bzl" >"$NEW"
+
+echo -n "NATIVE_TYPESCRIPT_VERSIONS = " >>"$NEW"
+jq --arg rc "$RC_VERSION" --argjson existing "$EXISTING_NATIVE_VERSIONS" --slurpfile platforms "$PLATFORMS_JSON" "$NATIVE_VERSIONS_JQ_FILTER" "$REGISTRY_JSON" >>"$NEW"
 echo "" >>"$NEW"
 
 echo -n "TOOL_VERSIONS = " >>"$NEW"

--- a/ts/private/versions.bzl
+++ b/ts/private/versions.bzl
@@ -33,6 +33,31 @@ NATIVE_TYPESCRIPT_VERSIONS = {
             "typescript-win32-x64": "sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==",
         },
     },
+    "7.0.2": {
+        "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+        "native_package_integrities": {
+            "typescript-aix-ppc64": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "typescript-darwin-arm64": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "typescript-darwin-x64": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "typescript-freebsd-arm64": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "typescript-freebsd-x64": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "typescript-linux-arm": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "typescript-linux-arm64": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "typescript-linux-loong64": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "typescript-linux-mips64el": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "typescript-linux-ppc64": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "typescript-linux-riscv64": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "typescript-linux-s390x": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "typescript-linux-x64": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "typescript-netbsd-arm64": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "typescript-netbsd-x64": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "typescript-openbsd-arm64": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "typescript-openbsd-x64": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "typescript-sunos-x64": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "typescript-win32-arm64": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "typescript-win32-x64": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+        },
+    },
 }
 
 TOOL_VERSIONS = {


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Include ts7 in available versions, keep default at ts6 while tsgo has issues with bazel sandboxing on macos.

### Test plan

- Covered by existing test cases
