### PR TITLE
perf: calculate all ts_project output paths in a single pass over srcs

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -362,19 +362,27 @@ def ts_project(
     declarations_target_name = None
     transpile_target_name = None
 
-    # typing predeclared outputs
-    tsc_typings_outs = []
-    tsc_typing_maps_outs = []
-    if emit_tsc_dts:
-        tsc_typings_outs = _lib.calculate_typings_outs(srcs, typings_out_dir, root_dir, declaration, composite, allow_js)
-        tsc_typing_maps_outs = _lib.calculate_typing_maps_outs(srcs, typings_out_dir, root_dir, declaration_map, allow_js)
-
-    # js predeclared outputs
-    tsc_js_outs = []
-    tsc_map_outs = []
-    if emit_tsc_js:
-        tsc_js_outs = _lib.calculate_js_outs(srcs, out_dir, root_dir, allow_js, resolve_json_module, preserve_jsx, emit_declaration_only)
-        tsc_map_outs = _lib.calculate_map_outs(srcs, out_dir, root_dir, source_map, allow_js, preserve_jsx, emit_declaration_only)
+    # tsc predeclared outputs (js, map, typings, typing maps), computed in a single pass over srcs
+    tsc_outs = _lib.calculate_outs(
+        srcs = srcs,
+        out_dir = out_dir,
+        typings_out_dir = typings_out_dir,
+        root_dir = root_dir,
+        allow_js = allow_js,
+        resolve_json_module = resolve_json_module,
+        preserve_jsx = preserve_jsx,
+        emit_declaration_only = emit_declaration_only,
+        source_map = source_map,
+        declaration = declaration,
+        composite = composite,
+        declaration_map = declaration_map,
+        emit_js = emit_tsc_js,
+        emit_dts = emit_tsc_dts,
+    )
+    tsc_js_outs = tsc_outs.js_outs
+    tsc_map_outs = tsc_outs.map_outs
+    tsc_typings_outs = tsc_outs.typings_outs
+    tsc_typing_maps_outs = tsc_outs.typing_maps_outs
 
     # Custom typing transpiler
     if emit_transpiler_dts:

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -257,20 +257,6 @@ def _to_out_path(f, out_dir, root_dir):
         f = out_dir + "/" + f
     return f
 
-def _to_js_out_paths(srcs, out_dir, root_dir, allow_js, resolve_json_module, ext_map, default_ext):
-    outs = []
-    for f in srcs:
-        if _is_ts_src(f, allow_js, resolve_json_module, False):
-            out = _to_out_path(f, out_dir, root_dir)
-            ext_idx = out.rindex(".")
-            out = out[:ext_idx] + ext_map.get(out[ext_idx:], default_ext)
-
-            # Don't declare outputs that collide with inputs
-            # for example, a.js -> a.js
-            if out != f:
-                outs.append(out)
-    return outs
-
 # Quick check to validate path options
 # One usecase: https://github.com/aspect-build/rules_ts/issues/551
 def _validate_tsconfig_dirs(root_dir, out_dir, typings_out_dir):
@@ -283,66 +269,131 @@ def _validate_tsconfig_dirs(root_dir, out_dir, typings_out_dir):
     if typings_out_dir and typings_out_dir.find("../") != -1:
         fail("typings_out_dir cannot output to parent directory")
 
-def _calculate_js_outs(srcs, out_dir, root_dir, allow_js, resolve_json_module, preserve_jsx, emit_declaration_only):
-    if emit_declaration_only:
-        return []
+def _with_jsx_exts(exts, jsx_out_ext):
+    d = dict(exts)
+    d[".jsx"] = jsx_out_ext
+    d[".tsx"] = jsx_out_ext
+    return d
 
-    exts = {
-        ".mts": ".mjs",
-        ".mjs": ".mjs",
-        ".cjs": ".cjs",
-        ".cts": ".cjs",
-        ".json": ".json",
-    }
+# Maps of src extension -> output extension for each emit type. The _PRESERVE_JSX
+# variants additionally map .jsx/.tsx to jsx outputs. Note that .jsx srcs only pass
+# _is_ts_src when allow_js is set, so unused entries are harmless.
+_JS_OUT_EXTS = {
+    ".mts": ".mjs",
+    ".mjs": ".mjs",
+    ".cjs": ".cjs",
+    ".cts": ".cjs",
+    ".json": ".json",
+}
+_JS_OUT_EXTS_PRESERVE_JSX = _with_jsx_exts(_JS_OUT_EXTS, ".jsx")
+_MAP_OUT_EXTS = {
+    ".mts": ".mjs.map",
+    ".cts": ".cjs.map",
+    ".mjs": ".mjs.map",
+    ".cjs": ".cjs.map",
+}
+_MAP_OUT_EXTS_PRESERVE_JSX = _with_jsx_exts(_MAP_OUT_EXTS, ".jsx.map")
+_DTS_OUT_EXTS = {
+    ".mts": ".d.mts",
+    ".cts": ".d.cts",
+    ".mjs": ".d.mts",
+    ".cjs": ".d.cts",
+}
+_DTS_MAP_OUT_EXTS = {
+    ".mts": ".d.mts.map",
+    ".cts": ".d.cts.map",
+    ".mjs": ".d.mts.map",
+    ".cjs": ".d.cts.map",
+}
 
-    if preserve_jsx:
-        exts[".jsx"] = ".jsx"
-        exts[".tsx"] = ".jsx"
+def _calculate_outs(
+        srcs,
+        out_dir,
+        typings_out_dir,
+        root_dir,
+        allow_js,
+        resolve_json_module,
+        preserve_jsx,
+        emit_declaration_only,
+        source_map,
+        declaration,
+        composite,
+        declaration_map,
+        emit_js,
+        emit_dts):
+    """Calculate js, map, typings and typing map output paths in a single pass over srcs.
 
-    return _to_js_out_paths(srcs, out_dir, root_dir, allow_js, resolve_json_module, exts, ".js")
+    Args:
+        srcs: list of source path strings, relative to the package
+        out_dir: `out_dir` attribute of ts_project
+        typings_out_dir: `declaration_dir` attribute of ts_project, falling back to `out_dir`
+        root_dir: `root_dir` attribute of ts_project
+        allow_js: `allow_js` attribute of ts_project
+        resolve_json_module: `resolve_json_module` attribute of ts_project
+        preserve_jsx: `preserve_jsx` attribute of ts_project
+        emit_declaration_only: `emit_declaration_only` attribute of ts_project
+        source_map: `source_map` attribute of ts_project
+        declaration: `declaration` attribute of ts_project
+        composite: `composite` attribute of ts_project
+        declaration_map: `declaration_map` attribute of ts_project
+        emit_js: whether tsc emits js (and source map) outputs for this target
+        emit_dts: whether tsc emits declaration (and declaration map) outputs for this target
 
-def _calculate_map_outs(srcs, out_dir, root_dir, source_map, allow_js, preserve_jsx, emit_declaration_only):
-    if not source_map or emit_declaration_only:
-        return []
+    Returns:
+        struct with js_outs, map_outs, typings_outs and typing_maps_outs path lists
+    """
+    want_js = emit_js and not emit_declaration_only
+    want_map = want_js and source_map
+    want_dts = emit_dts and (declaration or composite)
+    want_dts_map = emit_dts and declaration_map
 
-    exts = {
-        ".mts": ".mjs.map",
-        ".cts": ".cjs.map",
-        ".mjs": ".mjs.map",
-        ".cjs": ".cjs.map",
-    }
-    if preserve_jsx:
-        exts[".tsx"] = ".jsx.map"
-        if allow_js:
-            exts[".jsx"] = ".jsx.map"
+    js_outs = []
+    map_outs = []
+    typings_outs = []
+    typing_maps_outs = []
 
-    return _to_js_out_paths(srcs, out_dir, root_dir, allow_js, False, exts, ".js.map")
+    if not (want_js or want_dts or want_dts_map):
+        return struct(js_outs = js_outs, map_outs = map_outs, typings_outs = typings_outs, typing_maps_outs = typing_maps_outs)
 
-def _calculate_typings_outs(srcs, typings_out_dir, root_dir, declaration, composite, allow_js):
-    if not (declaration or composite):
-        return []
+    js_exts = _JS_OUT_EXTS_PRESERVE_JSX if preserve_jsx else _JS_OUT_EXTS
+    map_exts = _MAP_OUT_EXTS_PRESERVE_JSX if preserve_jsx else _MAP_OUT_EXTS
+    same_out_dirs = typings_out_dir == out_dir
 
-    exts = {
-        ".mts": ".d.mts",
-        ".cts": ".d.cts",
-        ".mjs": ".d.mts",
-        ".cjs": ".d.cts",
-    }
+    for f in srcs:
+        is_ts = _is_ts_src(f, allow_js, False, False)
+        is_json = want_js and resolve_json_module and f.endswith(".json")
+        if not is_ts and not is_json:
+            continue
 
-    return _to_js_out_paths(srcs, typings_out_dir, root_dir, allow_js, False, exts, ".d.ts")
+        out = None
+        if want_js or (want_map and is_ts):
+            out = _to_out_path(f, out_dir, root_dir)
+            ext_idx = out.rindex(".")
+            if want_js:
+                js_out = out[:ext_idx] + js_exts.get(out[ext_idx:], ".js")
 
-def _calculate_typing_maps_outs(srcs, typings_out_dir, root_dir, declaration_map, allow_js):
-    if not declaration_map:
-        return []
+                # Don't declare outputs that collide with inputs
+                # for example, a.js -> a.js
+                if js_out != f:
+                    js_outs.append(js_out)
+            if want_map and is_ts:
+                map_out = out[:ext_idx] + map_exts.get(out[ext_idx:], ".js.map")
+                if map_out != f:
+                    map_outs.append(map_out)
 
-    exts = {
-        ".mts": ".d.mts.map",
-        ".cts": ".d.cts.map",
-        ".mjs": ".d.mts.map",
-        ".cjs": ".d.cts.map",
-    }
+        if (want_dts or want_dts_map) and is_ts:
+            t_out = out if (same_out_dirs and out != None) else _to_out_path(f, typings_out_dir, root_dir)
+            ext_idx = t_out.rindex(".")
+            if want_dts:
+                dts_out = t_out[:ext_idx] + _DTS_OUT_EXTS.get(t_out[ext_idx:], ".d.ts")
+                if dts_out != f:
+                    typings_outs.append(dts_out)
+            if want_dts_map:
+                dts_map_out = t_out[:ext_idx] + _DTS_MAP_OUT_EXTS.get(t_out[ext_idx:], ".d.ts.map")
+                if dts_map_out != f:
+                    typing_maps_outs.append(dts_map_out)
 
-    return _to_js_out_paths(srcs, typings_out_dir, root_dir, allow_js, False, exts, ".d.ts.map")
+    return struct(js_outs = js_outs, map_outs = map_outs, typings_outs = typings_outs, typing_maps_outs = typing_maps_outs)
 
 def _calculate_root_dir(ctx):
     return _join(
@@ -364,12 +415,8 @@ lib = struct(
     is_typings_src = _is_typings_src,
     is_ts_src = _is_ts_src,
     is_js_src = _is_js_src,
-    out_paths = _to_js_out_paths,
     to_out_path = _to_out_path,
     validate_tsconfig_dirs = _validate_tsconfig_dirs,
-    calculate_js_outs = _calculate_js_outs,
-    calculate_map_outs = _calculate_map_outs,
-    calculate_typings_outs = _calculate_typings_outs,
-    calculate_typing_maps_outs = _calculate_typing_maps_outs,
+    calculate_outs = _calculate_outs,
     calculate_root_dir = _calculate_root_dir,
 )

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -107,19 +107,30 @@ def _ts_project_impl(ctx):
     # recalculated here.
     typings_out_dir = ctx.attr.declaration_dir or ctx.attr.out_dir
 
+    outs = _lib.calculate_outs(
+        srcs = srcs,
+        out_dir = ctx.attr.out_dir,
+        typings_out_dir = typings_out_dir,
+        root_dir = ctx.attr.root_dir,
+        allow_js = ctx.attr.allow_js,
+        resolve_json_module = ctx.attr.resolve_json_module,
+        preserve_jsx = ctx.attr.preserve_jsx,
+        emit_declaration_only = ctx.attr.emit_declaration_only,
+        source_map = ctx.attr.source_map,
+        declaration = ctx.attr.declaration,
+        composite = ctx.attr.composite,
+        declaration_map = ctx.attr.declaration_map,
+        emit_js = not ctx.attr.no_emit and ctx.attr.transpile != 0,
+        emit_dts = not ctx.attr.no_emit and not ctx.attr.declaration_transpile,
+    )
+
     # js+map file outputs
-    js_outs = []
-    map_outs = []
-    if not ctx.attr.no_emit and ctx.attr.transpile != 0:
-        js_outs = _lib.declare_outputs(ctx, _lib.calculate_js_outs(srcs, ctx.attr.out_dir, ctx.attr.root_dir, ctx.attr.allow_js, ctx.attr.resolve_json_module, ctx.attr.preserve_jsx, ctx.attr.emit_declaration_only))
-        map_outs = _lib.declare_outputs(ctx, _lib.calculate_map_outs(srcs, ctx.attr.out_dir, ctx.attr.root_dir, ctx.attr.source_map, ctx.attr.allow_js, ctx.attr.preserve_jsx, ctx.attr.emit_declaration_only))
+    js_outs = _lib.declare_outputs(ctx, outs.js_outs)
+    map_outs = _lib.declare_outputs(ctx, outs.map_outs)
 
     # dts+map file outputs
-    typings_outs = []
-    typing_maps_outs = []
-    if not ctx.attr.no_emit and not ctx.attr.declaration_transpile:
-        typings_outs = _lib.declare_outputs(ctx, _lib.calculate_typings_outs(srcs, typings_out_dir, ctx.attr.root_dir, ctx.attr.declaration, ctx.attr.composite, ctx.attr.allow_js))
-        typing_maps_outs = _lib.declare_outputs(ctx, _lib.calculate_typing_maps_outs(srcs, typings_out_dir, ctx.attr.root_dir, ctx.attr.declaration_map, ctx.attr.allow_js))
+    typings_outs = _lib.declare_outputs(ctx, outs.typings_outs)
+    typing_maps_outs = _lib.declare_outputs(ctx, outs.typing_maps_outs)
 
     validation_outs = []
     if ctx.attr.validate:
@@ -218,12 +229,12 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
 
     # Add JS inputs that collide with outputs (see #250).
     #
-    # Unfortunately this duplicates logic in ts_lib._to_js_out_paths:
+    # Unfortunately this duplicates logic in ts_lib.calculate_outs:
     # files collide iff the following conditions are met:
     # - They are files not renamed when transpiled (ext in [.d.ts, js, json])
     # - out_dir == root_dir
     #
-    # The duplication is hard to avoid, since out_paths works on path strings
+    # The duplication is hard to avoid, since calculate_outs works on path strings
     # (so it also works in the macro), but we need Files here.
     if ctx.attr.out_dir == ctx.attr.root_dir:
         for s in srcs_inputs:

--- a/ts/test/BUILD.bazel
+++ b/ts/test/BUILD.bazel
@@ -3,9 +3,12 @@ load(":flags_test.bzl", "ts_project_flags_test_suite")
 load(":mock_transpiler.bzl", "mock")
 load(":transpiler_tests.bzl", "transpiler_test_suite")
 load(":ts_config_test.bzl", "ts_config_test_suite")
+load(":ts_lib_test.bzl", "ts_lib_test_suite")
 load(":ts_project_test.bzl", "ts_project_test_suite")
 
 transpiler_test_suite()
+
+ts_lib_test_suite(name = "ts_lib_test")
 
 ts_project_test_suite(name = "ts_project_test")
 

--- a/ts/test/mock_transpiler.bzl
+++ b/ts/test/mock_transpiler.bzl
@@ -45,15 +45,32 @@ mock_impl = rule(
 )
 
 def mock(name, srcs, source_map = False, **kwargs):
+    # Calculate pre-declared outputs so they can be referenced as targets.
+    # This is an optional transpiler feature aligning with the default tsc transpiler.
+    outs = lib.calculate_outs(
+        srcs = srcs,
+        out_dir = None,
+        typings_out_dir = None,
+        root_dir = None,
+        allow_js = False,
+        resolve_json_module = False,
+        preserve_jsx = False,
+        emit_declaration_only = False,
+        source_map = source_map,
+        declaration = False,
+        composite = False,
+        declaration_map = False,
+        emit_js = True,
+        emit_dts = False,
+    )
+
     # Run the rule producing those pre-declared outputs as well as any other outputs
     # which can not be determined ahead of time such as within directories, goruped
     # within a filegroup() etc.
     mock_impl(
         name = name,
         srcs = srcs,
-        # Calculate pre-declared outputs so they can be referenced as targets.
-        # This is an optional transpiler feature aligning with the default tsc transpiler.
-        js_outs = lib.calculate_js_outs(srcs, None, None, False, False, False, False),
-        map_outs = lib.calculate_map_outs(srcs, None, None, True, False, False, False) if source_map else [],
+        js_outs = outs.js_outs,
+        map_outs = outs.map_outs,
         **kwargs
     )

--- a/ts/test/ts_lib_test.bzl
+++ b/ts/test/ts_lib_test.bzl
@@ -1,0 +1,173 @@
+"""UnitTests for ts_lib output path calculation"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//ts/private:ts_lib.bzl", "lib")
+
+# Cover typescript, jsx, module variants, typings, js, json, assets, label syntax and subdirectories
+_SRCS = [
+    "a.ts",
+    "b.tsx",
+    "sub/c.mts",
+    "sub/d.cts",
+    "e.d.ts",
+    "typings.d.mts",
+    "f.js",
+    "g.jsx",
+    "h.mjs",
+    "i.cjs",
+    "j.json",
+    "k.css",
+    ":l.ts",
+    "sub/dir/m.ts",
+]
+
+def _outs_golden_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # All emit types enabled: js+map+dts+dts.map with allow_js and resolve_json_module.
+    # Note js/json srcs whose js out collides with the input (f.js -> f.js) are dropped.
+    outs = lib.calculate_outs(
+        srcs = _SRCS,
+        out_dir = None,
+        typings_out_dir = None,
+        root_dir = None,
+        allow_js = True,
+        resolve_json_module = True,
+        preserve_jsx = False,
+        emit_declaration_only = False,
+        source_map = True,
+        declaration = True,
+        composite = False,
+        declaration_map = True,
+        emit_js = True,
+        emit_dts = True,
+    )
+    asserts.equals(env, ["a.js", "b.js", "sub/c.mjs", "sub/d.cjs", "g.js", "l.js", "sub/dir/m.js"], outs.js_outs)
+    asserts.equals(env, ["a.js.map", "b.js.map", "sub/c.mjs.map", "sub/d.cjs.map", "f.js.map", "g.js.map", "h.mjs.map", "i.cjs.map", "l.js.map", "sub/dir/m.js.map"], outs.map_outs)
+    asserts.equals(env, ["a.d.ts", "b.d.ts", "sub/c.d.mts", "sub/d.d.cts", "f.d.ts", "g.d.ts", "h.d.mts", "i.d.cts", "l.d.ts", "sub/dir/m.d.ts"], outs.typings_outs)
+    asserts.equals(env, ["a.d.ts.map", "b.d.ts.map", "sub/c.d.mts.map", "sub/d.d.cts.map", "f.d.ts.map", "g.d.ts.map", "h.d.mts.map", "i.d.cts.map", "l.d.ts.map", "sub/dir/m.d.ts.map"], outs.typing_maps_outs)
+
+    # out_dir, declaration_dir and root_dir remapping with preserve_jsx (no allow_js)
+    outs = lib.calculate_outs(
+        srcs = ["a.ts", "b.tsx", "sub/c.ts"],
+        out_dir = "dist",
+        typings_out_dir = "types",
+        root_dir = "sub",
+        allow_js = False,
+        resolve_json_module = False,
+        preserve_jsx = True,
+        emit_declaration_only = False,
+        source_map = True,
+        declaration = True,
+        composite = False,
+        declaration_map = False,
+        emit_js = True,
+        emit_dts = True,
+    )
+    asserts.equals(env, ["dist/a.js", "dist/b.jsx", "dist/c.js"], outs.js_outs)
+    asserts.equals(env, ["dist/a.js.map", "dist/b.jsx.map", "dist/c.js.map"], outs.map_outs)
+    asserts.equals(env, ["types/a.d.ts", "types/b.d.ts", "types/c.d.ts"], outs.typings_outs)
+    asserts.equals(env, [], outs.typing_maps_outs)
+
+    # preserve_jsx with allow_js: .jsx srcs collide with their js out but still produce a map
+    outs = lib.calculate_outs(
+        srcs = _SRCS,
+        out_dir = None,
+        typings_out_dir = None,
+        root_dir = None,
+        allow_js = True,
+        resolve_json_module = False,
+        preserve_jsx = True,
+        emit_declaration_only = False,
+        source_map = True,
+        declaration = False,
+        composite = False,
+        declaration_map = False,
+        emit_js = True,
+        emit_dts = False,
+    )
+    asserts.equals(env, ["a.js", "b.jsx", "sub/c.mjs", "sub/d.cjs", "l.js", "sub/dir/m.js"], outs.js_outs)
+    asserts.equals(env, ["a.js.map", "b.jsx.map", "sub/c.mjs.map", "sub/d.cjs.map", "f.js.map", "g.jsx.map", "h.mjs.map", "i.cjs.map", "l.js.map", "sub/dir/m.js.map"], outs.map_outs)
+    asserts.equals(env, [], outs.typings_outs)
+    asserts.equals(env, [], outs.typing_maps_outs)
+
+    # emit_declaration_only suppresses js+map outputs even when emit_js is set
+    outs = lib.calculate_outs(
+        srcs = _SRCS,
+        out_dir = None,
+        typings_out_dir = None,
+        root_dir = None,
+        allow_js = False,
+        resolve_json_module = False,
+        preserve_jsx = False,
+        emit_declaration_only = True,
+        source_map = True,
+        declaration = True,
+        composite = False,
+        declaration_map = True,
+        emit_js = True,
+        emit_dts = True,
+    )
+    asserts.equals(env, [], outs.js_outs)
+    asserts.equals(env, [], outs.map_outs)
+    asserts.equals(env, ["a.d.ts", "b.d.ts", "sub/c.d.mts", "sub/d.d.cts", "l.d.ts", "sub/dir/m.d.ts"], outs.typings_outs)
+    asserts.equals(env, ["a.d.ts.map", "b.d.ts.map", "sub/c.d.mts.map", "sub/d.d.cts.map", "l.d.ts.map", "sub/dir/m.d.ts.map"], outs.typing_maps_outs)
+
+    # composite without declaration still emits typings; source_map off suppresses maps
+    outs = lib.calculate_outs(
+        srcs = _SRCS,
+        out_dir = None,
+        typings_out_dir = None,
+        root_dir = None,
+        allow_js = False,
+        resolve_json_module = False,
+        preserve_jsx = False,
+        emit_declaration_only = False,
+        source_map = False,
+        declaration = False,
+        composite = True,
+        declaration_map = False,
+        emit_js = True,
+        emit_dts = True,
+    )
+    asserts.equals(env, ["a.js", "b.js", "sub/c.mjs", "sub/d.cjs", "l.js", "sub/dir/m.js"], outs.js_outs)
+    asserts.equals(env, [], outs.map_outs)
+    asserts.equals(env, ["a.d.ts", "b.d.ts", "sub/c.d.mts", "sub/d.d.cts", "l.d.ts", "sub/dir/m.d.ts"], outs.typings_outs)
+    asserts.equals(env, [], outs.typing_maps_outs)
+
+    # no_emit-style invocation produces nothing
+    outs = lib.calculate_outs(
+        srcs = _SRCS,
+        out_dir = None,
+        typings_out_dir = None,
+        root_dir = None,
+        allow_js = True,
+        resolve_json_module = True,
+        preserve_jsx = True,
+        emit_declaration_only = False,
+        source_map = True,
+        declaration = True,
+        composite = True,
+        declaration_map = True,
+        emit_js = False,
+        emit_dts = False,
+    )
+    asserts.equals(env, [], outs.js_outs)
+    asserts.equals(env, [], outs.map_outs)
+    asserts.equals(env, [], outs.typings_outs)
+    asserts.equals(env, [], outs.typing_maps_outs)
+
+    return unittest.end(env)
+
+_outs_golden_test = unittest.make(_outs_golden_test_impl)
+
+def ts_lib_test_suite(name):
+    """Test suite for ts_lib output calculation
+
+    Args:
+        name: name of the test suite target
+    """
+    unittest.suite(
+        name,
+        _outs_golden_test,
+    )


### PR DESCRIPTION
The ts_project macro and rule implementation each scanned srcs up to four times (js, map, typings, typing maps), re-deriving the extension and out path of every src on each pass. Large repos pay this during loading and again during analysis for every ts_project target.

Add lib.calculate_outs which produces all four lists in one pass, hoist the extension tables to module-level constants (previously rebuilt per call), and switch both call sites. The individual calculate_*_outs functions remain for custom transpiler macros that use them.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
