### PR TITLE
refactor: drop redundant copy_files_to_bin_actions pass over tsconfig_inputs

### DIFF
--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -93,7 +93,9 @@ def _ts_project_impl(ctx):
 
     srcs_deps = ctx.attr.srcs + ctx.attr.deps
 
-    tsc_inputs = srcs_inputs + copy_files_to_bin_actions(ctx, tsconfig_inputs)
+    # tsconfig_inputs are already outputs of copy-to-bin actions (see _gather_tsconfig_deps),
+    # so there is no need to pass them through copy_files_to_bin_actions again.
+    tsc_inputs = srcs_inputs + tsconfig_inputs
     tsc_inputs_depset = depset(tsc_inputs, transitive = [tsconfig_transitive_deps])
     tsc_transitive_inputs_depset = depset(tsc_inputs, transitive = [
         _gather_types_from_js_infos(srcs_deps),


### PR DESCRIPTION
tsconfig_inputs are already outputs of the copy-to-bin actions created in _gather_tsconfig_deps, so passing them through
copy_files_to_bin_actions again in the rule implementation was a no-op iteration over every tsconfig input of every ts_project target.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
