### PR TITLE
perf: reduce per-file string work in write_tsconfig and srcs path relativization

### DIFF
--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -136,18 +136,23 @@ def _write_tsconfig_rule(ctx):
     path_to_root = "/".join([".."] * (ctx.label.package.count("/") + 1))
 
     # Compute the list of source files with paths relative to the generated tsconfig file.
+    allow_js = ctx.attr.allow_js
+    resolve_json_module = ctx.attr.resolve_json_module
+    local_package_prefix_len = len(local_package_prefix)
+    root_prefix = "./%s/" % path_to_root
     src_files = []
     for f in ctx.files.files:
         # Only include typescript source files
-        if not _lib.is_ts_src(f.basename, ctx.attr.allow_js, ctx.attr.resolve_json_module, True):
+        if not _lib.is_ts_src(f.basename, allow_js, resolve_json_module, True):
             continue
 
-        if f.short_path.startswith(local_package_prefix):
+        short_path = f.short_path
+        if short_path.startswith(local_package_prefix):
             # Files within this project or subdirs can avoid the ugly ../ prefix
-            src_files.append("./{}".format(f.short_path.removeprefix(local_package_prefix)))
+            src_files.append("./" + short_path[local_package_prefix_len:])
         else:
             # Files from parent/sibling projects must navigate up to the workspace root
-            src_files.append("./{}/{}".format(path_to_root, f.short_path))
+            src_files.append(root_prefix + short_path)
 
     content = content.replace("\"__files__\"", str(src_files))
     ctx.actions.write(

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -219,13 +219,21 @@ def _join(*elements):
         return "/".join(segments)
     return "."
 
-def _relative_to_package(path, ctx):
-    path = path.removeprefix(ctx.bin_dir.path + "/")
-    path = path.removeprefix("external/")
-    path = path.removeprefix(ctx.label.workspace_name + "/")
-    if ctx.label.package:
-        path = path.removeprefix(ctx.label.package + "/")
-    return path
+def _files_relative_to_package(ctx, files):
+    """Package-relative paths for a list of files, computing the prefixes only once."""
+    bin_dir_prefix = ctx.bin_dir.path + "/"
+    workspace_prefix = ctx.label.workspace_name + "/"
+    package_prefix = ctx.label.package + "/" if ctx.label.package else None
+
+    paths = []
+    for file in files:
+        path = file.path.removeprefix(bin_dir_prefix)
+        path = path.removeprefix("external/")
+        path = path.removeprefix(workspace_prefix)
+        if package_prefix:
+            path = path.removeprefix(package_prefix)
+        paths.append(path)
+    return paths
 
 _TYPINGS_EXTS = (".d.ts", ".d.mts", ".d.cts")
 _JS_EXTS = (".js", ".jsx", ".mjs", ".cjs")
@@ -415,7 +423,7 @@ def _declare_outputs(ctx, paths):
 lib = struct(
     declare_outputs = _declare_outputs,
     join = _join,
-    relative_to_package = _relative_to_package,
+    files_relative_to_package = _files_relative_to_package,
     is_typings_src = _is_typings_src,
     is_ts_src = _is_ts_src,
     is_js_src = _is_js_src,

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -89,7 +89,7 @@ def _ts_project_impl(ctx):
     srcs_inputs = copy_files_to_bin_actions(ctx, ctx.files.srcs)
     tsconfig, tsconfig_inputs, tsconfig_transitive_deps = _gather_tsconfig_deps(ctx)
 
-    srcs = [_lib.relative_to_package(src.path, ctx) for src in srcs_inputs]
+    srcs = _lib.files_relative_to_package(ctx, srcs_inputs)
 
     srcs_deps = ctx.attr.srcs + ctx.attr.deps
 
@@ -209,8 +209,8 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
     ])
 
     assets_outs = []
-    for a in ctx.files.assets:
-        a_path = _lib.relative_to_package(a.path, ctx)
+    asset_paths = _lib.files_relative_to_package(ctx, ctx.files.assets)
+    for a, a_path in zip(ctx.files.assets, asset_paths):
         a_out = _lib.to_out_path(a_path, ctx.attr.out_dir, ctx.attr.root_dir)
         if a.is_source or a_path != a_out:
             asset = ctx.actions.declare_file(a_out)

--- a/ts/test/mock_transpiler.bzl
+++ b/ts/test/mock_transpiler.bzl
@@ -6,13 +6,12 @@ _DUMMY_SOURCEMAP = """{"version":3,"sources":["%s"],"mappings":"AAAO,KAAK,CAAC",
 
 def _mock_impl(ctx):
     src_files = [src for src in ctx.files.srcs if src.short_path.endswith(".ts") and not src.short_path.endswith(".d.ts")]
+    src_paths = lib.files_relative_to_package(ctx, src_files)
     out_files = []
 
-    for src in src_files:
-        out_path = src.short_path
-
-        js_file = ctx.actions.declare_file(lib.relative_to_package(out_path.replace(".ts", ".js"), ctx))
-        map_file = ctx.actions.declare_file(lib.relative_to_package(out_path.replace(".ts", ".js.map"), ctx))
+    for src, src_path in zip(src_files, src_paths):
+        js_file = ctx.actions.declare_file(src_path.replace(".ts", ".js"))
+        map_file = ctx.actions.declare_file(src_path.replace(".ts", ".js.map"))
 
         out_files.append(js_file)
         out_files.append(map_file)


### PR DESCRIPTION
_write_tsconfig_rule re-read attributes and re-built prefix strings for every file in the loop, and relative_to_package re-concatenated the bin dir, workspace and package prefixes for every src of every ts_project. Hoist the loop invariants and add
lib.files_relative_to_package which computes the prefixes once per target.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
