### PR TITLE
refactor!: validate ts_project attributes with `tsc --showConfig`

### DIFF
--- a/e2e/nested_repos/BUILD.bazel
+++ b/e2e/nested_repos/BUILD.bazel
@@ -7,7 +7,10 @@ build_test(
 
 build_test(
     name = "module_b_consumer_test",
-    targets = ["@module_b//:consumer"],
+    targets = [
+        "@module_b//:consumer",
+        "@module_b//:consumer_shared",
+    ],
 )
 
 build_test(

--- a/e2e/nested_repos/module_a/BUILD.bazel
+++ b/e2e/nested_repos/module_a/BUILD.bazel
@@ -5,6 +5,15 @@ ts_config(
     src = "tsconfig.json",
 )
 
+# A tsconfig consumed by a ts_project in another module, see @module_b//:consumer_shared.
+# The "include" navigates to the consuming repository, listing both the `~` and `+`
+# external repository name separators to work across bazel versions.
+ts_config(
+    name = "tsconfig_shared",
+    src = "tsconfig-shared.json",
+    visibility = ["//visibility:public"],
+)
+
 ts_project(
     name = "content",
     srcs = ["content.ts"],

--- a/e2e/nested_repos/module_a/tsconfig-shared.json
+++ b/e2e/nested_repos/module_a/tsconfig-shared.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "declaration": true
+    },
+    "include": ["../module_b~/shared.ts", "../module_b+/shared.ts"]
+}

--- a/e2e/nested_repos/module_b/BUILD.bazel
+++ b/e2e/nested_repos/module_b/BUILD.bazel
@@ -15,3 +15,15 @@ ts_project(
     visibility = ["//visibility:public"],
     deps = ["@module_a//:content"],
 )
+
+# Validate against a tsconfig owned by another module: both resolution and the
+# validator's temporary wrapper config happen in the other repository's directory.
+# The `declaration` attribute mirrors an option set only in that tsconfig, so
+# validation fails if resolution breaks.
+ts_project(
+    name = "consumer_shared",
+    srcs = ["shared.ts"],
+    declaration = True,
+    tsconfig = "@module_a//:tsconfig_shared",
+    visibility = ["//visibility:public"],
+)

--- a/e2e/nested_repos/module_b/shared.ts
+++ b/e2e/nested_repos/module_b/shared.ts
@@ -1,0 +1,1 @@
+export const shared = 1

--- a/examples/tsconfig_external/BUILD.bazel
+++ b/examples/tsconfig_external/BUILD.bazel
@@ -13,5 +13,7 @@ ts_project(
     srcs = [
         "index.ts",
     ],
+    # @tsconfig/strictest sets allowJs: true
+    allow_js = True,
     tsconfig = ":config",
 )

--- a/examples/tsconfig_locations/BUILD.bazel
+++ b/examples/tsconfig_locations/BUILD.bazel
@@ -1,0 +1,34 @@
+"""Validation of tsconfig files located outside the ts_project package.
+
+The validator resolves the tsconfig (and writes its temporary wrapper config)
+in the directory containing the tsconfig, wherever that is: a parent package
+(see //tsconfig_locations/lib), a child package (":use_child") or another
+repository (see e2e/nested_repos). The `declaration` attribute mirrors an
+option set only in the tsconfig, so validation fails if resolution breaks.
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+# The tsconfig used by the child package //tsconfig_locations/lib
+ts_config(
+    name = "tsconfig_parent",
+    src = "tsconfig-parent.json",
+    visibility = [":__subpackages__"],
+)
+
+# A tsconfig in a child package
+ts_project(
+    name = "use_child",
+    srcs = ["child_user.ts"],
+    declaration = True,
+    tsconfig = "//tsconfig_locations/config:tsconfig",
+)
+
+build_test(
+    name = "test",
+    targets = [
+        ":use_child",
+        "//tsconfig_locations/lib",
+    ],
+)

--- a/examples/tsconfig_locations/child_user.ts
+++ b/examples/tsconfig_locations/child_user.ts
@@ -1,0 +1,1 @@
+export const childUser = 1

--- a/examples/tsconfig_locations/config/BUILD.bazel
+++ b/examples/tsconfig_locations/config/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//tsconfig_locations:__pkg__"],
+)

--- a/examples/tsconfig_locations/config/tsconfig.json
+++ b/examples/tsconfig_locations/config/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "declaration": true
+    },
+    "include": ["../*.ts"]
+}

--- a/examples/tsconfig_locations/lib/BUILD.bazel
+++ b/examples/tsconfig_locations/lib/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# A tsconfig in the parent package
+ts_project(
+    name = "lib",
+    srcs = ["lib.ts"],
+    declaration = True,
+    tsconfig = "//tsconfig_locations:tsconfig_parent",
+    visibility = ["//tsconfig_locations:__pkg__"],
+)

--- a/examples/tsconfig_locations/lib/lib.ts
+++ b/examples/tsconfig_locations/lib/lib.ts
@@ -1,0 +1,1 @@
+export const lib = 1

--- a/examples/tsconfig_locations/tsconfig-parent.json
+++ b/examples/tsconfig_locations/tsconfig-parent.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "declaration": true
+    }
+}

--- a/ts/private/ts_project_options_validator.cjs
+++ b/ts/private/ts_project_options_validator.cjs
@@ -1,75 +1,9 @@
 'use strict'
 exports.__esModule = true
 var path_1 = require('path')
-// Resolve the tsconfig "extends" chain to a single config, equivalent to what
-// `tsc --showConfig -p <tsconfig>` prints. Classic TypeScript (< 7) exposes the
-// compiler API to node so this runs in-process; native TypeScript (>= 7) ships no
-// JS API, so the same output is obtained by spawning the compiler CLI instead.
-function resolveConfig(tsconfigPath) {
-    var ts
-    try {
-        ts = require('typescript')
-    } catch (e) {
-        ts = null
-    }
-    if (ts && typeof ts.getParsedCommandLineOfConfigFile === 'function') {
-        return resolveConfigViaApi(ts, tsconfigPath)
-    }
-    return resolveConfigViaShowConfig(tsconfigPath)
-}
-function resolveConfigViaApi(ts, tsconfigPath) {
-    var diagnosticsHost = {
-        getCurrentDirectory: function () {
-            return ts.sys.getCurrentDirectory()
-        },
-        getNewLine: function () {
-            return ts.sys.newLine
-        },
-        // Print filenames including their relativeRoot, so they can be located on
-        // disk
-        getCanonicalFileName: function (f) {
-            return f
-        },
-    }
-    var host = {
-        fileExists: ts.sys.fileExists,
-        readFile: ts.sys.readFile,
-        readDirectory: ts.sys.readDirectory,
-        getCurrentDirectory: function () {
-            return ts.sys.getCurrentDirectory()
-        },
-        useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
-        onUnRecoverableConfigFileDiagnostic: function (d) {
-            throw new Error(
-                tsconfigPath + ':' + ts.formatDiagnostic(d, diagnosticsHost)
-            )
-        },
-    }
-    var parsed = ts.getParsedCommandLineOfConfigFile(
-        tsconfigPath,
-        undefined,
-        host
-    )
-    // We don't pass the srcs to this action, so it can't know if the program has the right sources.
-    // error TS18002: The 'files' list in config file 'tsconfig.json' is empty.
-    // error TS18003: No inputs were found in config file 'tsconfig.json'. Specified 'include'...
-    var fatalErrors = parsed.errors.filter(function (e) {
-        return e.code !== 18002 && e.code !== 18003
-    })
-    if (fatalErrors.length > 0)
-        throw new Error(
-            tsconfigPath +
-                ':' +
-                ts.formatDiagnostics(fatalErrors, diagnosticsHost)
-        )
-    var config = ts.convertToTSConfig(parsed, tsconfigPath, ts.sys)
-    relativizeConfigPaths(config, tsconfigPath)
-    // Only keep "files" when the original config specified it; a glob-based config
-    // resolves it from this action's inputs (the tsconfig chain, not the srcs).
-    if (!Array.isArray(parsed.raw && parsed.raw.files)) delete config.files
-    return JSON.parse(JSON.stringify(config))
-}
-function resolveConfigViaShowConfig(tsconfigPath) {
+// Resolve the tsconfig options to a single config by spawning `tsc --showConfig`.
+function resolveConfig(tsconfigPath, output) {
+    var fs = require('fs')
     // require('typescript') is blocked by the native package's exports map, but
     // ./package.json is always resolvable; anchor the compiler CLI on it.
     var tscBin = path_1.join(
@@ -77,17 +11,44 @@ function resolveConfigViaShowConfig(tsconfigPath) {
         'bin',
         'tsc'
     )
-    var stdout = require('child_process').execFileSync(
-        process.execPath,
-        [tscBin, '--project', tsconfigPath, '--showConfig'],
-        { encoding: 'utf-8' }
+    // The srcs are not inputs to this action, so resolve a wrapper config declaring
+    // empty "files": TypeScript < 7 --showConfig fails when a config finds no inputs
+    // (TS18003). The wrapper must be alongside the tsconfig so relative paths resolve
+    // identically. NOTE: delete the wrapper once TypeScript < 7 support is removed.
+    var wrapperPath = path_1.join(
+        path_1.dirname(tsconfigPath),
+        (output + '.showconfig.json').replace(/[^\w.-]/g, '_')
     )
+    fs.writeFileSync(
+        wrapperPath,
+        JSON.stringify({
+            extends: './' + path_1.basename(tsconfigPath),
+            files: [],
+        }),
+        'utf-8'
+    )
+    var stdout
+    try {
+        stdout = require('child_process').execFileSync(
+            process.execPath,
+            [tscBin, '--project', wrapperPath, '--showConfig'],
+            { encoding: 'utf-8' }
+        )
+    } catch (e) {
+        // tsc prints config diagnostics to stdout and exits without JSON
+        throw new Error(
+            tsconfigPath +
+                ': tsc --showConfig failed:\n' +
+                (e.stdout || e.message)
+        )
+    } finally {
+        fs.unlinkSync(wrapperPath)
+    }
     var config = JSON.parse(stdout)
     relativizeConfigPaths(config, tsconfigPath)
-    // "files" is resolved from this action's inputs, not the compile, and is never
-    // validated, so drop it.
+    // "files" is the wrapper's empty list, not the compile's, and is never validated.
     delete config.files
-    return JSON.parse(JSON.stringify(config))
+    return config
 }
 // tsc materializes some paths as absolute, e.g. the implicit exclusion of outDir.
 // Absolute paths under the execroot are not hermetic (sandbox paths differ across
@@ -139,10 +100,9 @@ function main(_a) {
     // The Bazel ts_project attributes were json-encoded
     // (on Windows the quotes seem to be quoted wrong, so replace backslash with quotes :shrug:)
     var attrs = JSON.parse(attrsStr.replace(/\\/g, '"'))
-    // The resolved config, in `tsc --showConfig` shape. The checks below read this
-    // JSON only, so they run identically whether it was resolved in-process or by
-    // the native compiler CLI.
-    var config = resolveConfig(tsconfigPath)
+    // The resolved config, in `tsc --showConfig` shape, which the checks below
+    // read in place of the raw tsconfig file(s).
+    var config = resolveConfig(tsconfigPath, output)
     var options = config.compilerOptions || {}
     var configDir = path_1.dirname(path_1.resolve(tsconfigPath))
     var failures = []
@@ -371,38 +331,11 @@ function main(_a) {
         return 1
     }
     // We have to write an output so that Bazel needs to execute this action.
-    // Make the output change whenever the attributes changed.
+    // The resolved config doubles as a debugging aid: it is the flattened view
+    // of the tsconfig that the attributes were validated against.
     require('fs').writeFileSync(
         output,
-        '\n// checked attributes for ' +
-            target +
-            '\n// allow_js:              ' +
-            attrs.allow_js +
-            '\n// composite:             ' +
-            attrs.composite +
-            '\n// declaration:           ' +
-            attrs.declaration +
-            '\n// declaration_map:       ' +
-            attrs.declaration_map +
-            '\n// out_dir:               ' +
-            attrs.out_dir +
-            '\n// declaration_dir:       ' +
-            attrs.declaration_dir +
-            '\n// incremental:           ' +
-            attrs.incremental +
-            '\n// source_map:            ' +
-            attrs.source_map +
-            '\n// no_emit:               ' +
-            attrs.no_emit +
-            '\n// emit_declaration_only: ' +
-            attrs.emit_declaration_only +
-            '\n// ts_build_info_file:    ' +
-            attrs.ts_build_info_file +
-            '\n// preserve_jsx:          ' +
-            attrs.preserve_jsx +
-            '\n// root_dir:              ' +
-            attrs.root_dir +
-            '\n',
+        JSON.stringify(config, null, 4) + '\n',
         'utf-8'
     )
     return 0
@@ -423,5 +356,6 @@ if (require.main === module) {
         }
     } catch (e) {
         console.error(process.argv[1], e)
+        process.exitCode = 1
     }
 }

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -6,11 +6,13 @@ load(":ts_lib.bzl", _lib = "lib")
 def _validate_action(ctx, tsconfig, tsconfig_deps):
     """Create an action to validate the ts_project attributes against the tsconfig.json properties.
 
+The validator invokes the equivalent of `tsc --showConfig` programmatically to flatten
+the tsconfig "extends" chain, checks the attributes against the resolved config, and
+writes the resolved config as the validation output.
+
 Assumes all tsconfig file deps are already copied to the bin directory.
 """
-
-    # Bazel validation actions must still produce an output file.
-    marker = ctx.actions.declare_file("%s_params.validation" % ctx.label.name)
+    resolved = ctx.actions.declare_file("%s.resolved.tsconfig.json" % ctx.label.name)
 
     arguments = ctx.actions.args()
     config = struct(
@@ -32,7 +34,7 @@ Assumes all tsconfig file deps are already copied to the bin directory.
     )
     arguments.add_all([
         to_output_relative_path(tsconfig),
-        to_output_relative_path(marker),
+        to_output_relative_path(resolved),
         str(ctx.label),
         _lib.join(ctx.label.workspace_root, ctx.label.package),
         json.encode(config),
@@ -41,7 +43,7 @@ Assumes all tsconfig file deps are already copied to the bin directory.
     ctx.actions.run(
         executable = ctx.executable.validator,
         inputs = tsconfig_deps,
-        outputs = [marker],
+        outputs = [resolved],
         arguments = [arguments],
         mnemonic = "TsValidateOptions",
         env = {
@@ -50,7 +52,7 @@ Assumes all tsconfig file deps are already copied to the bin directory.
         use_default_shell_env = True,
     )
 
-    return [marker]
+    return [resolved]
 
 lib = struct(
     validation_action = _validate_action,

--- a/ts/test/dir.resolved.tsconfig.golden
+++ b/ts/test/dir.resolved.tsconfig.golden
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "allowJs": false,
+        "declaration": true,
+        "declarationMap": false,
+        "emitDeclarationOnly": false,
+        "noEmit": false,
+        "sourceMap": true
+    }
+}

--- a/ts/test/ts_project_test.bzl
+++ b/ts/test/ts_project_test.bzl
@@ -3,6 +3,7 @@
 load("@aspect_rules_js//js:providers.bzl", "JsInfo")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//ts:defs.bzl", "ts_project")
 
@@ -164,6 +165,23 @@ def ts_project_test_suite(name):
     _dir_test(
         name = "dir_test",
         target_under_test = "dir",
+    )
+
+    # Pin the content of the resolved tsconfig emitted by the validation action.
+    # This is the contract a replacement resolver (e.g. a native `tsc --showConfig`
+    # action for typescript >= 7) must reproduce.
+    # NB: the golden deliberately has no .json extension: formatters would reformat
+    # it away from the byte-exact validator output.
+    native.filegroup(
+        name = "dir_validation_output",
+        srcs = [":dir"],
+        output_group = "_validation",
+        tags = ["manual"],
+    )
+    diff_test(
+        name = "dir_resolved_tsconfig_test",
+        file1 = "dir.resolved.tsconfig.golden",
+        file2 = ":dir_validation_output",
     )
 
     write_file(


### PR DESCRIPTION
This expands the rules_ts 3.x typescript 7 `tsc --showConfig` logic (https://github.com/aspect-build/rules_ts/pull/969) to also apply to typescript <7 so we have a single implementation.

Currently (typescript 7.0.2) typescript 7 is not as strict as typescript 5,6 so an extra generated `{extends: "./realConfigjson", files: []}` is required for 5,6 - but we're doing it 100% of the time just for simplicity. A lot of the test cases added are to ensure this generated tsconfig works when in parent/children dirs, different repos etc.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Some previously unsupported/undetected tsconfig validation (config vs `ts_project` attribute) issues will now be caught such as invalid `ts_project` attributes based on the a tsconfig.json which extends from an npm package. The extended npm package may now be correctly taken into account.

### Test plan

- Covered by existing test cases
- New test cases added
