### PR TITLE
refactor!: replace aspect_bazel_lib@2 with bazel-lib@3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.19.2")
+bazel_dep(name = "bazel_lib", version = "3.1.0")
 bazel_dep(name = "aspect_tools_telemetry", version = "0.4.2")
 bazel_dep(name = "aspect_rules_js", version = "3.0.1")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/e2e/test/dir_as_source.bats
+++ b/e2e/test/dir_as_source.bats
@@ -12,7 +12,7 @@ teardown() {
 @test 'ts_project with a directory in srcs should fail to build' {
 	workspace
 	cat >>MODULE.bazel <<EOF
-bazel_dep(name = "aspect_bazel_lib", version = "2.19.2")
+bazel_dep(name = "bazel_lib", version = "3.1.0")
 EOF
 	tsconfig
 	mkdir inputs
@@ -21,7 +21,7 @@ EOF
 
 	cat >>BUILD.bazel <<EOF
 
-load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
+load("@bazel_lib//lib:copy_directory.bzl", "copy_directory")
 
 copy_directory(
     name = "code_generation",

--- a/e2e/worker/BUILD
+++ b/e2e/worker/BUILD
@@ -1,5 +1,5 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.20.0", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.1.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "3.0.1", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 

--- a/e2e/worker/composite/BUILD.bazel
+++ b/e2e/worker/composite/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 package(default_visibility = ["//composite:__subpackages__"])
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -5,7 +5,6 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "protobuf", version = "33.4")
 
 # Minimum versions for bazel_lib and bazel9 compat
-bazel_dep(name = "aspect_bazel_lib", version = "2.22.5", repo_name = None)
 bazel_dep(name = "rules_nodejs", version = "6.7.3", repo_name = None)
 
 local_path_override(

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
+load("@bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("//ts/private:options.bzl", "options")
@@ -139,9 +139,9 @@ bzl_library(
         "//ts/private:options",
         "//ts/private:ts_config",
         "//ts/private:ts_project",
-        "@aspect_bazel_lib//lib:utils",
         "@aspect_rules_js//js:defs",
         "@aspect_tools_telemetry_report//:defs.bzl",
+        "@bazel_lib//lib:utils",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//rules:build_test",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
@@ -175,13 +175,13 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//ts/private:ts_proto_library",
-        "@aspect_bazel_lib//lib:copy_to_directory",
-        "@aspect_bazel_lib//lib:directory_path",
-        "@aspect_bazel_lib//lib:platform_utils",
-        "@aspect_bazel_lib//lib:write_source_files",
         "@aspect_rules_js//js:defs",
         "@aspect_rules_js//js:libs",
         "@aspect_rules_js//js:providers",
+        "@bazel_lib//lib:copy_to_directory",
+        "@bazel_lib//lib:directory_path",
+        "@bazel_lib//lib:platform_utils",
+        "@bazel_lib//lib:write_source_files",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
 )
 

--- a/ts/BUILD.typescript
+++ b/ts/BUILD.typescript
@@ -1,6 +1,6 @@
 "BUILD file inserted into @npm_typescript repository"
 
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
+load("@bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@aspect_rules_js//npm/private:npm_package_internal.bzl", "npm_package_internal")

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -4,8 +4,8 @@ The most commonly used is the [ts_project](#function-ts_project) macro which acc
 inputs and produces JavaScript or declaration (.d.ts) outputs.
 """
 
-load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
+load("@bazel_lib//lib:utils.bzl", "to_label")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("//ts/private:build_test.bzl", "build_test")
 load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")

--- a/ts/private/BUILD.bazel
+++ b/ts/private/BUILD.bazel
@@ -23,10 +23,10 @@ bzl_library(
     visibility = ["//ts:__subpackages__"],
     deps = [
         ":ts_lib",
-        "@aspect_bazel_lib//lib:copy_to_bin",
-        "@aspect_bazel_lib//lib:paths",
         "@aspect_rules_js//js:libs",
         "@aspect_rules_js//js:providers",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:paths",
     ],
 )
 
@@ -49,14 +49,14 @@ bzl_library(
         ":ts_config",
         ":ts_lib",
         ":ts_validate_options",
-        "@aspect_bazel_lib//lib:copy_file",
-        "@aspect_bazel_lib//lib:copy_to_bin",
-        "@aspect_bazel_lib//lib:paths",
-        "@aspect_bazel_lib//lib:platform_utils",
-        "@aspect_bazel_lib//lib:resource_sets",
         "@aspect_rules_js//js:libs",
         "@aspect_rules_js//js:providers",
         "@aspect_rules_js//npm:providers",
+        "@bazel_lib//lib:copy_file",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:paths",
+        "@bazel_lib//lib:platform_utils",
+        "@bazel_lib//lib:resource_sets",
         "@bazel_skylib//lib:dicts",
     ],
 )
@@ -68,9 +68,9 @@ bzl_library(
     deps = [
         ":ts_config",
         ":ts_lib",
-        "@aspect_bazel_lib//lib:copy_to_bin",
-        "@aspect_bazel_lib//lib:paths",
         "@aspect_rules_js//js:providers",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:paths",
     ],
 )
 
@@ -79,7 +79,8 @@ bzl_library(
     srcs = ["ts_proto_library.bzl"],
     visibility = ["//ts:__subpackages__"],
     deps = [
-        "@aspect_bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:platform_utils",
         "@bazel_skylib//lib:paths",
         "@rules_proto//proto:defs",
     ],

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -14,10 +14,10 @@
 
 "tsconfig.json files using extends"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
-load("@aspect_bazel_lib//lib:paths.bzl", "relative_file")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "js_info")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
+load("@bazel_lib//lib:paths.bzl", "relative_file")
 load(":ts_lib.bzl", _lib = "lib")
 
 TsConfigInfo = provider(

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -1,12 +1,12 @@
 "ts_project rule"
 
-load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file_action")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
-load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
-load("@aspect_bazel_lib//lib:platform_utils.bzl", "platform_utils")
-load("@aspect_bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
+load("@bazel_lib//lib:copy_file.bzl", "copy_file_action")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
+load("@bazel_lib//lib:paths.bzl", "to_output_relative_path")
+load("@bazel_lib//lib:platform_utils.bzl", "platform_utils")
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":options.bzl", "OptionsInfo", "transpiler_selection_required")
 load(":ts_config.bzl", "TsConfigInfo")

--- a/ts/private/ts_proto_library.bzl
+++ b/ts/private/ts_proto_library.bzl
@@ -1,7 +1,7 @@
 "Private implementation details for ts_proto_library"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
-load("@aspect_bazel_lib//lib:platform_utils.bzl", "platform_utils")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
+load("@bazel_lib//lib:platform_utils.bzl", "platform_utils")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common")
 load("@rules_proto//proto:proto_common.bzl", proto_toolchains = "toolchains")
 

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -1,6 +1,6 @@
 "Helper rule to check that ts_project attributes match tsconfig.json properties"
 
-load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
+load("@bazel_lib//lib:paths.bzl", "to_output_relative_path")
 load(":ts_lib.bzl", _lib = "lib")
 
 def _validate_action(ctx, tsconfig, tsconfig_deps):

--- a/ts/proto.bzl
+++ b/ts/proto.bzl
@@ -27,10 +27,10 @@ Future work
 - Allow users to control the output format. Currently it is hard-coded to `js+dts`, and the JS output uses ES Modules.
 """
 
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path", "make_directory_path")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
+load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_lib//lib:directory_path.bzl", "directory_path", "make_directory_path")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("//ts/private:ts_proto_library.bzl", ts_proto_library_rule = "ts_proto_library")
 
 def ts_proto_library(name, node_modules, proto, protoc_gen_options = {}, gen_connect_es = False, gen_connect_query = False, gen_connect_query_service_mapping = {}, copy_files = True, proto_srcs = None, files_to_copy = None, **kwargs):


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

All use of `aspect_bazel_lib` (v2) has been replaced with `bazel-lib` (v3) in alignment with `aspect_rules_js` v3 and the general ruleset community.

### Test plan

- Covered by existing test cases
