### PR TITLE
docs: correct broken anchor links in docstrings for Bazel registry docs

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -1,6 +1,6 @@
 """# Public API for TypeScript rules
 
-The most commonly used is the [ts_project](#ts_project) macro which accepts TypeScript sources as
+The most commonly used is the [ts_project](#function-ts_project) macro which accepts TypeScript sources as
 inputs and produces JavaScript or declaration (.d.ts) outputs.
 """
 
@@ -260,7 +260,7 @@ def ts_project(
             - `0`: Override the global flag, disabling workers for this target.
             - `1`: Override the global flag, enabling workers for this target.
 
-        **kwargs: passed through to underlying [`ts_project_rule`](#ts_project_rule), eg. `visibility`, `tags`
+        **kwargs: passed through to underlying [`ts_project_rule`](#rule-ts_project_rule), eg. `visibility`, `tags`
     """
 
     tsc_deps = deps

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -445,7 +445,7 @@ lib = struct(
 
 ts_project = rule(
     doc = """Implementation rule behind the ts_project macro.
-    Most users should use [ts_project](#ts_project) instead.
+    Most users should use [ts_project](#function-ts_project) instead.
 
     This skips conveniences like validation of the tsconfig attributes, default settings
     for srcs and tsconfig, and pre-declaring output files.


### PR DESCRIPTION
## Summary
The Bazel registry (registry.bazel.build) renders function/macro definition anchors with a `function-` prefix and rule anchors with a `rule-` prefix (e.g. `id="function-ts_project"`), but the docstring links used bare names (e.g. `#ts_project`), causing the links to not navigate to the correct section.

- `#ts_project` -> `#function-ts_project` in module docstring and `ts_project_rule` docstring
- `#ts_project_rule` -> `#rule-ts_project_rule` in `ts_project` macro docstring

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no

### Test plan
Manual testing:
1. Visit https://registry.bazel.build/docs/aspect_rules_ts
2. Click the "ts_project" link in the module description at the top — currently doesn't navigate
3. In the `ts_project` macro kwargs, click the "ts_project_rule" link — currently doesn't navigate
4. In the `ts_project_rule` rule description, click the "ts_project" link — currently doesn't navigate
5. After this fix, all three links navigate to the correct sections