### PR TITLE
fix: validate native TypeScript with TypeScript 6

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -260,7 +260,7 @@
   "moduleExtensions": {
     "//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
         "usagesDigest": "TD1QE8SIsIe/1auNN+/8H40h7PindVljd5SMGA2fju4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -272,6 +272,7 @@
             "attributes": {
               "version": "5.6.2",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/e2e/bzlmodules/MODULE.bazel.lock
+++ b/e2e/bzlmodules/MODULE.bazel.lock
@@ -146,7 +146,7 @@
   "moduleExtensions": {
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
         "usagesDigest": "FpN2Qu/qXxwtDzlEUwR/WIa09ID2f6LvshcR5PJU/S4=",
         "recordedFileInputs": {
           "@@module_a~//package.json": "35a3409de097fcc0d3c6eea7fd7090b8f3c9cbbf7d05c8c010372bccc85aa374"
@@ -161,6 +161,7 @@
               "version": "",
               "version_from": "@@module_a~//:package.json",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/e2e/external_dep/BUILD
+++ b/e2e/external_dep/BUILD
@@ -1,5 +1,6 @@
 """Tests a `ts_project()` in one workspace being used in another."""
 
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -31,11 +32,19 @@ ts_project(
 )
 
 ts_project(
-    name = "lib.ts7rc",
+    name = "lib.ts7",
     srcs = ["lib.ts"],
     composite = True,
-    out_dir = "ts7rc_out",
-    tsc = "@npm_typescript-7rc//:tsc",
+    out_dir = "ts7_out",
+    tsc = "@npm_typescript-7//:tsc",
+    validator = "@npm_typescript-7//:validator",
+)
+
+js_test(
+    name = "validator_version_test",
+    args = ["$(rootpath @npm_typescript-7_validator//:node_modules/typescript/dir)"],
+    data = ["@npm_typescript-7_validator//:node_modules/typescript/dir"],
+    entry_point = "validator_version_test.cjs",
 )
 
 build_test(
@@ -44,7 +53,8 @@ build_test(
         ":lib",
         "lib.ts5",
         "lib.ts56rc",
-        "lib.ts7rc",
+        "lib.ts7",
+        "validator_version_test",
     ],
 )
 

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -8,6 +8,7 @@ local_path_override(
     path = "../..",
 )
 
+bazel_dep(name = "aspect_rules_js", version = "3.0.1")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
@@ -26,12 +27,14 @@ rules_ts_ext.deps(
     ts_version = "5.6.1-rc",
 )
 
-# Example of a native rc version
+# Example of a native TypeScript version
 rules_ts_ext.deps(
-    name = "npm_typescript-7rc",
-    ts_version = "7.0.1-rc",
+    name = "npm_typescript-7",
+    ts_version = "7.0.2",
+    validator_ts_integrity = "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+    validator_ts_version = "6.0.2",
 )
-use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript-7rc", "npm_typescript5")
+use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript-7", "npm_typescript-7_validator", "npm_typescript5")
 
 bazel_dep(name = "sub_external", version = "0.0.0", dev_dependency = True)
 local_path_override(

--- a/e2e/external_dep/MODULE.bazel.lock
+++ b/e2e/external_dep/MODULE.bazel.lock
@@ -145,8 +145,8 @@
   "moduleExtensions": {
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
-        "usagesDigest": "PsXy3Rmja6SBXL2YWH+2ZQQ45ttrsdAYIyqWJbZ9Ulk=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
+        "usagesDigest": "lv0xPDAGokPkO/uIw/L5BWnR+GttDdFFnjh/e/KZdZw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -157,6 +157,7 @@
             "attributes": {
               "version": "6.0.3",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
@@ -168,6 +169,7 @@
             "attributes": {
               "version": "5.0.4",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
@@ -179,17 +181,31 @@
             "attributes": {
               "version": "5.6.1-rc",
               "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
             }
           },
-          "npm_typescript-7rc": {
+          "npm_typescript-7_validator": {
             "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
             "ruleClassName": "http_archive_version",
             "attributes": {
-              "version": "7.0.1-rc",
+              "version": "6.0.2",
+              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+              "validator_repository": "",
+              "urls": [
+                "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
+              ]
+            }
+          },
+          "npm_typescript-7": {
+            "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
+            "ruleClassName": "http_archive_version",
+            "attributes": {
+              "version": "7.0.2",
               "integrity": "",
+              "validator_repository": "npm_typescript-7_validator",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
@@ -201,6 +217,7 @@
             "attributes": {
               "version": "6.0.3",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
@@ -224,7 +241,7 @@
     "@@aspect_tools_telemetry~//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "4w9RM0xjdKo1crk5zL20a/TuhqO0P1z1LsuXDneBXD4=",
-        "usagesDigest": "nNMLgMchPC1maq2zDITmrTxOlDagx8Ez4AlNp9a/Gao=",
+        "usagesDigest": "rRzP6u9PuRVT7oI+DGsDtKhMtg4jYkdpYO9C/jXRv5A=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {
@@ -237,8 +254,8 @@
             "attributes": {
               "deps": {
                 "aspect_rules_ts": "",
-                "aspect_tools_telemetry": "0.4.2",
-                "aspect_rules_js": "3.0.1"
+                "aspect_rules_js": "3.0.1",
+                "aspect_tools_telemetry": "0.4.2"
               },
               "last_notice": 1
             }

--- a/e2e/external_dep/app/MODULE.bazel.lock
+++ b/e2e/external_dep/app/MODULE.bazel.lock
@@ -145,8 +145,8 @@
   "moduleExtensions": {
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
-        "usagesDigest": "En5SiSexpKW8wmqMwvy5J8do84+ImOE6FtqWovuDTg4=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
+        "usagesDigest": "zg6ZOv5TMWbPZ3eJcirOn8nVo+g9a+E4RxKlu+L7qmM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -157,6 +157,7 @@
             "attributes": {
               "version": "6.0.3",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
@@ -168,6 +169,7 @@
             "attributes": {
               "version": "5.0.4",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
@@ -179,17 +181,31 @@
             "attributes": {
               "version": "5.6.1-rc",
               "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]
             }
           },
-          "npm_typescript-7rc": {
+          "npm_typescript-7_validator": {
             "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
             "ruleClassName": "http_archive_version",
             "attributes": {
-              "version": "7.0.1-rc",
+              "version": "6.0.2",
+              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+              "validator_repository": "",
+              "urls": [
+                "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
+              ]
+            }
+          },
+          "npm_typescript-7": {
+            "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
+            "ruleClassName": "http_archive_version",
+            "attributes": {
+              "version": "7.0.2",
               "integrity": "",
+              "validator_repository": "npm_typescript-7_validator",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/e2e/external_dep/validator_version_test.cjs
+++ b/e2e/external_dep/validator_version_test.cjs
@@ -1,0 +1,11 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { readFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const packageJson = JSON.parse(
+    readFileSync(join(process.argv[2], 'package.json'), 'utf8')
+)
+assert.equal(packageJson.name, 'typescript')
+assert.equal(packageJson.version, '6.0.2')

--- a/e2e/nested_repos/MODULE.bazel.lock
+++ b/e2e/nested_repos/MODULE.bazel.lock
@@ -146,7 +146,7 @@
   "moduleExtensions": {
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
         "usagesDigest": "QQrKqBIMeJ2QsnnVGW4HXt6/cOsu2PFEVQ6z3JbkYk4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -158,6 +158,7 @@
             "attributes": {
               "version": "5.9.2",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/e2e/smoke/MODULE.bazel.lock
+++ b/e2e/smoke/MODULE.bazel.lock
@@ -184,7 +184,7 @@
   "moduleExtensions": {
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
         "usagesDigest": "/z4ca+1z/VCydEk0MwLyKPL107p9F5XvIgbvZZhwt3Y=",
         "recordedFileInputs": {
           "@@//package.json": "e8abba115559110ae0bb22355c2817b6387f054074cd53dfae07ea995fe8e37b"
@@ -199,6 +199,7 @@
               "version": "",
               "version_from": "@@//:package.json",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/examples/MODULE.bazel.lock
+++ b/examples/MODULE.bazel.lock
@@ -222,7 +222,7 @@
   "moduleExtensions": {
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "WV+DuevmiFUeiSXIrDC1IEJov1WdDAy3pSFgQHHEFA0=",
+        "bzlTransitiveDigest": "RkR48+6Lt+KMO8Bg/pygR6AnfZsD+KSvc1RfSf+lplc=",
         "usagesDigest": "m9vAevWyTf4y9vIKdK6eSHhJblTDPJcGMXzaYykrt+Y=",
         "recordedFileInputs": {
           "@@//package.json": "7121d883692b35c8aec1e353c7cd9151c628ef4d3450898c20efd036f383a87a"
@@ -237,6 +237,7 @@
               "version": "",
               "version_from": "@@//:package.json",
               "integrity": "",
+              "validator_repository": "",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/ts/BUILD.typescript
+++ b/ts/BUILD.typescript
@@ -1,10 +1,11 @@
 "BUILD file inserted into @npm_typescript repository"
 
-load("@bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@aspect_rules_js//npm/private:npm_package_internal.bzl", "npm_package_internal")
+load("@bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
 npm_package_internal(
     name = "npm_typescript",
     src = "package",
@@ -48,8 +49,13 @@ copy_file(
 )
 
 js_binary(
-    name = "validator",
+    name = "validator_impl",
     data = TSC_DATA,
     entry_point = "copy_validator",
+)
+
+alias(
+    name = "validator",
+    actual = "VALIDATOR_ACTUAL",
     visibility = ["//visibility:public"],
 )

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -2,10 +2,11 @@
 See https://bazel.build/docs/bzlmod#extension-definition
 """
 
-load("//ts/private:npm_repositories.bzl", "npm_dependencies")
-load("//ts/private:versions.bzl", "TOOL_VERSIONS")
+load("//ts/private:npm_repositories.bzl", "npm_dependencies", "parse_typescript_version")
+load("//ts/private:versions.bzl", "NATIVE_TYPESCRIPT_VERSIONS", "TOOL_VERSIONS")
 
 LATEST_TYPESCRIPT_VERSION = TOOL_VERSIONS.keys()[-1]
+_DEFAULT_VALIDATOR_TYPESCRIPT_VERSION = "6.0.3"
 
 def _extension_impl(module_ctx):
     # Prefer the root module's tag when multiple modules request the same repo.
@@ -20,20 +21,26 @@ def _extension_impl(module_ctx):
                     existing_attr = existing["attr"]
                     if attr.ts_version != existing_attr.ts_version or \
                        attr.ts_version_from != existing_attr.ts_version_from or \
-                       attr.ts_integrity != existing_attr.ts_integrity:
+                       attr.ts_integrity != existing_attr.ts_integrity or \
+                       attr.validator_ts_version != existing_attr.validator_ts_version or \
+                       attr.validator_ts_integrity != existing_attr.validator_ts_integrity:
                         fail("""Multiple non-root modules specify different versions for '{name}'.
-    Module '{existing_mod}' requests: ts_version={existing_version}, ts_version_from={existing_from}, ts_integrity={existing_integrity}
-    Module '{current_mod}' requests: ts_version={current_version}, ts_version_from={current_from}, ts_integrity={current_integrity}
+    Module '{existing_mod}' requests: ts_version={existing_version}, ts_version_from={existing_from}, ts_integrity={existing_integrity}, validator_ts_version={existing_validator_version}, validator_ts_integrity={existing_validator_integrity}
+    Module '{current_mod}' requests: ts_version={current_version}, ts_version_from={current_from}, ts_integrity={current_integrity}, validator_ts_version={current_validator_version}, validator_ts_integrity={current_validator_integrity}
 To resolve this conflict, the root module should explicitly specify the desired version.""".format(
                             name = attr.name,
                             existing_mod = existing["module_name"],
                             existing_version = existing_attr.ts_version or "(not set)",
                             existing_from = existing_attr.ts_version_from or "(not set)",
                             existing_integrity = existing_attr.ts_integrity or "(not set)",
+                            existing_validator_integrity = existing_attr.validator_ts_integrity or "(not set)",
+                            existing_validator_version = existing_attr.validator_ts_version or "(not set)",
                             current_mod = mod.name,
                             current_version = attr.ts_version or "(not set)",
                             current_from = attr.ts_version_from or "(not set)",
                             current_integrity = attr.ts_integrity or "(not set)",
+                            current_validator_integrity = attr.validator_ts_integrity or "(not set)",
+                            current_validator_version = attr.validator_ts_version or "(not set)",
                         ))
                 continue
             selected[attr.name] = {
@@ -50,11 +57,32 @@ To resolve this conflict, the root module should explicitly specify the desired 
         ts_version = attr.ts_version
         if not ts_version and not attr.ts_version_from:
             ts_version = LATEST_TYPESCRIPT_VERSION
+        resolved_ts_version = ts_version
+        if attr.ts_version_from:
+            resolved_ts_version, _ = parse_typescript_version(module_ctx.read(attr.ts_version_from), attr.ts_version_from)
+
+        validator_repository = None
+        if resolved_ts_version in NATIVE_TYPESCRIPT_VERSIONS:
+            validator_ts_version = attr.validator_ts_version or _DEFAULT_VALIDATOR_TYPESCRIPT_VERSION
+            if not validator_ts_version.startswith("6."):
+                fail("validator_ts_version must select a TypeScript 6 release, got {}".format(validator_ts_version))
+
+            validator_repository = "{}_validator".format(attr.name)
+            if validator_repository in selected:
+                fail("validator repository '{}' conflicts with an explicitly requested TypeScript repository".format(validator_repository))
+
+            npm_dependencies(
+                name = validator_repository,
+                ts_version = validator_ts_version,
+                ts_integrity = attr.validator_ts_integrity,
+            )
+
         npm_dependencies(
             name = attr.name,
             ts_version = ts_version,
             ts_version_from = attr.ts_version_from,
             ts_integrity = attr.ts_integrity,
+            validator_repository = validator_repository,
         )
 
 ext = module_extension(
@@ -65,6 +93,12 @@ ext = module_extension(
             "ts_version": attr.string(),
             "ts_version_from": attr.label(),
             "ts_integrity": attr.string(),
+            "validator_ts_integrity": attr.string(
+                doc = "Integrity of the classic TypeScript package used only to validate native TypeScript. Defaults to the mirrored integrity.",
+            ),
+            "validator_ts_version": attr.string(
+                doc = "Classic TypeScript version used only to validate native TypeScript. Defaults to 6.0.3.",
+            ),
         }),
     },
 )

--- a/ts/private/npm_repositories.bzl
+++ b/ts/private/npm_repositories.bzl
@@ -6,25 +6,26 @@ load("//ts/private:versions.bzl", "NATIVE_TYPESCRIPT_VERSIONS", "TOOL_VERSIONS")
 
 _TYPESCRIPT_NATIVE_PACKAGE_PREFIX = "@typescript/"
 
+def parse_typescript_version(content, json_path):
+    p = json.decode(content)
+
+    # Allow use of "resolved.json", see https://github.com/aspect-build/rules_js/pull/1221
+    if "$schema" in p.keys() and p["$schema"] == "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock":
+        return p["version"], p["integrity"]
+    elif "devDependencies" in p.keys() and "typescript" in p["devDependencies"]:
+        return p["devDependencies"]["typescript"], None
+    elif "dependencies" in p.keys() and "typescript" in p["dependencies"]:
+        return p["dependencies"]["typescript"], None
+    else:
+        fail("key 'typescript' not found in either dependencies or devDependencies of %s" % json_path)
+
 def _http_archive_version_impl(rctx):
     integrity = None
     if rctx.attr.version:
         version = rctx.attr.version
     else:
         json_path = rctx.path(rctx.attr.version_from)
-        p = json.decode(rctx.read(json_path))
-
-        # Allow use of "resolved.json", see https://github.com/aspect-build/rules_js/pull/1221
-        if "$schema" in p.keys() and p["$schema"] == "https://docs.aspect.build/rules/aspect_rules_js/docs/npm_translate_lock":
-            ts = p["version"]
-            integrity = p["integrity"]
-        elif "devDependencies" in p.keys() and "typescript" in p["devDependencies"]:
-            ts = p["devDependencies"]["typescript"]
-        elif "dependencies" in p.keys() and "typescript" in p["dependencies"]:
-            ts = p["dependencies"]["typescript"]
-        else:
-            fail("key 'typescript' not found in either dependencies or devDependencies of %s" % json_path)
-        version = ts
+        version, integrity = parse_typescript_version(rctx.read(json_path), json_path)
 
     # Note: we can't depend on bazel_skylib because this code is called from
     # rules_ts_dependencies so it's not "in scope" yet.
@@ -65,11 +66,14 @@ def _http_archive_version_impl(rctx):
     native_package_targets = []
     if native_typescript_version:
         native_package_labels, native_package_targets = _link_native_packages(rctx, version, native_typescript_version)
+        if not rctx.attr.validator_repository:
+            fail("native TypeScript version {} requires a validator repository".format(version))
 
     build_file_substitutions = {
         "ts_version": version,
         "# ts_native_package_labels": "".join(native_package_labels),
         "# ts_native_package_targets": "\n".join(native_package_targets),
+        "VALIDATOR_ACTUAL": "@{}//:validator".format(rctx.attr.validator_repository) if native_typescript_version else ":validator_impl",
     }
     rctx.template(
         "BUILD.bazel",
@@ -150,6 +154,7 @@ http_archive_version = repository_rule(
     implementation = _http_archive_version_impl,
     attrs = {
         "integrity": attr.string(doc = "Needed only if the ts version isn't mirrored in `versions.bzl`."),
+        "validator_repository": attr.string(doc = "Repository containing the classic TypeScript validator for a native TypeScript compiler."),
         "version": attr.string(doc = "Explicit version for `urls` placeholder. If provided, the package.json is not read."),
         "urls": attr.string_list(doc = "URLs to fetch from. Each must have one `{}`-style placeholder."),
         "_build_file": attr.label(
@@ -161,7 +166,7 @@ http_archive_version = repository_rule(
 )
 
 # buildifier: disable=function-docstring
-def npm_dependencies(name = "npm_typescript", ts_version_from = None, ts_version = None, ts_integrity = None):
+def npm_dependencies(name = "npm_typescript", ts_version_from = None, ts_version = None, ts_integrity = None, validator_repository = None):
     if (ts_version and ts_version_from) or (not ts_version_from and not ts_version):
         fail("""Exactly one of 'ts_version' or 'ts_version_from' must be set.""")
 
@@ -171,5 +176,6 @@ def npm_dependencies(name = "npm_typescript", ts_version_from = None, ts_version
         version = ts_version,
         version_from = ts_version_from,
         integrity = ts_integrity,
+        validator_repository = validator_repository or "",
         urls = ["https://registry.npmjs.org/typescript/-/typescript-{}.tgz"],
     )


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Native TypeScript builds now run `ts_project` option validation through a companion repository containing an exact classic TypeScript 6 release. The native compiler repository keeps its public `:validator` label and delegates to that companion. `validator_ts_version` and `validator_ts_integrity` let consumers pin the validator without adding a second package to the compiler repository's `node_modules` tree.

### Test plan

- `bazel test --lockfile_mode=error --distdir=/private/tmp //ts/...`
- `bazel test --lockfile_mode=error --distdir=/private/tmp //:validator_version_test` from `e2e/external_dep`
- `bazel build --lockfile_mode=error --distdir=/private/tmp @npm_typescript-7_validator//:validator` from `e2e/external_dep`
- Full Bazel 7/8/9 workspace matrix in CI
