### PR TITLE
fix: declare extension_metadata for the ts module extension

### DIFF
--- a/e2e/nested_repos/MODULE.bazel
+++ b/e2e/nested_repos/MODULE.bazel
@@ -28,6 +28,7 @@ local_path_override(
 
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
 rules_ts_ext.deps(ts_version = "5.9.2")
+use_repo(rules_ts_ext, "npm_typescript")
 
 # Override root MODULE with newer versions for bazel9 compat
 bazel_dep(name = "rules_nodejs", version = "6.7.3", dev_dependency = True, repo_name = None)

--- a/ts/extensions.bzl
+++ b/ts/extensions.bzl
@@ -8,9 +8,16 @@ load("//ts/private:npm_repositories.bzl", "npm_dependencies")
 def _extension_impl(module_ctx):
     # Prefer the root module's tag when multiple modules request the same repo.
     selected = {}
+    root_direct_deps = {}
+    root_direct_dev_deps = {}
     for mod in module_ctx.modules:
         is_root = hasattr(mod, "is_root") and mod.is_root
         for attr in mod.tags.deps:
+            if is_root:
+                if module_ctx.is_dev_dependency(attr):
+                    root_direct_dev_deps[attr.name] = None
+                else:
+                    root_direct_deps[attr.name] = None
             existing = selected.get(attr.name)
             if existing and not is_root:
                 # Validate that non-root modules don't specify conflicting versions
@@ -54,6 +61,25 @@ To resolve this conflict, the root module should explicitly specify the desired 
             ts_version_from = attr.ts_version_from,
             ts_integrity = attr.ts_integrity,
         )
+
+    # Bazel <6.2 lacks module_ctx.extension_metadata
+    if not hasattr(module_ctx, "extension_metadata"):
+        return None
+
+    # A repo requested by both dev and non-dev usages of the root module is a non-dev dep.
+    for name in root_direct_deps.keys():
+        root_direct_dev_deps.pop(name, None)
+
+    metadata_kwargs = {}
+    if hasattr(module_ctx, "watch"):
+        # Bazel 7.1+, the same release that added `reproducible`
+        metadata_kwargs["reproducible"] = True
+
+    return module_ctx.extension_metadata(
+        root_module_direct_deps = root_direct_deps.keys(),
+        root_module_direct_dev_deps = root_direct_dev_deps.keys(),
+        **metadata_kwargs
+    )
 
 ext = module_extension(
     implementation = _extension_impl,


### PR DESCRIPTION
#965 for the 3.x branch

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Declare module as `reproducible` and `report root_module_direct_*dep`s bzlmod extension info.

### Test plan

- Covered by existing test cases
