### PR TITLE
refactor: remove the underlying rule ts_project(extends) attribute and always pass ts_config()

### DIFF
--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -139,9 +139,13 @@ def ts_project(
 
             See [docs/tsconfig.md](/docs/tsconfig.md) for detailed information.
 
-        extends: Label of the tsconfig file referenced in the `extends` section of tsconfig
-            To support "chaining" of more than one extended config, this label could be a target that
-            provdes `TsConfigInfo` such as `ts_config`.
+        extends: Label of the tsconfig file referenced in the `extends` section of tsconfig.
+
+            Syntax sugar for a `ts_config` target: the `tsconfig` is wrapped in one declaring
+            this label in its `deps`. A dictionary `tsconfig` also gains an `extends` clause
+            with a relative path to this file.
+
+            Equivalent to passing a `ts_config` as the `tsconfig`, with this label in its `deps`.
 
         args: List of strings of additional command-line arguments to pass to tsc.
             See https://www.typescriptlang.org/docs/handbook/compiler-options.html#compiler-options
@@ -320,6 +324,18 @@ def ts_project(
             resolve_json_module = resolve_json_module,
         )
 
+    if extends != None:
+        # Syntax sugar for wrapping the tsconfig file in a ts_config target which
+        # declares the extended tsconfig files, so they reach actions via TsConfigInfo
+        # on the tsconfig attribute alone.
+        _ts_config(
+            name = "_tsconfig_%s" % name,
+            src = tsconfig,
+            deps = [extends],
+            **common_kwargs
+        )
+        tsconfig = ":_tsconfig_%s" % name
+
     # Normalize common directory path shortcuts such as None vs "." vs "./"
     out_dir = _clean_dir_arg(out_dir)
     root_dir = _clean_dir_arg(root_dir)
@@ -445,7 +461,6 @@ def ts_project(
         tsconfig = tsconfig,
         allow_js = allow_js,
         resolve_json_module = resolve_json_module,
-        extends = extends,
         incremental = incremental,
         preserve_jsx = preserve_jsx,
         composite = composite,

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -32,10 +32,14 @@ TsConfigInfo = provider(
 def _ts_config_impl(ctx):
     files = [copy_file_to_bin_action(ctx, ctx.file.src)]
 
+    # The src may be a target carrying tsconfig dependencies of its own, such as another
+    # ts_config, so gather from it as well as the direct deps.
+    dep_targets = [ctx.attr.src] + ctx.attr.deps
+
     transitive_deps = [
         depset(copy_files_to_bin_actions(ctx, ctx.files.deps)),
         js_lib_helpers.gather_files_from_js_infos(
-            targets = ctx.attr.deps,
+            targets = dep_targets,
             include_sources = True,
             include_types = True,
             include_transitive_sources = True,
@@ -46,21 +50,21 @@ def _ts_config_impl(ctx):
 
     # TODO: now that ts_config.bzl provides a JsInfo, we should be able to remove TsConfigInfo in the future
     # since transitive files will now be passed through transitive_types in JsInfo
-    for dep in ctx.attr.deps:
+    for dep in dep_targets:
         if TsConfigInfo in dep:
             transitive_deps.append(dep[TsConfigInfo].deps)
 
-    transitive_sources = js_lib_helpers.gather_transitive_sources(files, ctx.attr.deps)
+    transitive_sources = js_lib_helpers.gather_transitive_sources(files, dep_targets)
 
-    transitive_types = js_lib_helpers.gather_transitive_types([], ctx.attr.deps)
+    transitive_types = js_lib_helpers.gather_transitive_types([], dep_targets)
 
     npm_sources = js_lib_helpers.gather_npm_sources(
         srcs = [],
-        deps = ctx.attr.deps,
+        deps = dep_targets,
     )
 
     npm_package_store_infos = js_lib_helpers.gather_npm_package_store_infos(
-        targets = ctx.attr.deps,
+        targets = dep_targets,
     )
 
     files_depset = depset(files)
@@ -68,7 +72,7 @@ def _ts_config_impl(ctx):
     # tsconfig.json file won't be needed at runtime
     runfiles = js_lib_helpers.gather_runfiles(
         ctx = ctx,
-        deps = ctx.attr.deps,
+        deps = dep_targets,
     )
 
     return [

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -149,10 +149,6 @@ COMPILER_OPTION_ATTRS = {
     "emit_declaration_only": attr.bool(
         doc = "https://www.typescriptlang.org/tsconfig#emitDeclarationOnly",
     ),
-    "extends": attr.label(
-        allow_files = True,
-        doc = "https://www.typescriptlang.org/tsconfig#extends",
-    ),
     "incremental": attr.bool(
         doc = "https://www.typescriptlang.org/tsconfig#incremental",
     ),

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -39,16 +39,9 @@ def _gather_transitive_typecheck_from_output_group_infos(typecheck_outs, targets
 def _gather_tsconfig_deps(ctx):
     tsconfig = copy_file_to_bin_action(ctx, ctx.file.tsconfig)
 
-    # Gather TsConfig info from both the direct (tsconfig) and indirect (extends) attribute
-    tsconfig_inputs = [tsconfig] + copy_files_to_bin_actions(ctx, ctx.files.extends)
-
     deps = []
-
-    # Direct TsConfigInfo deps
     if TsConfigInfo in ctx.attr.tsconfig:
         deps.append(ctx.attr.tsconfig[TsConfigInfo].deps)
-    if ctx.attr.extends and TsConfigInfo in ctx.attr.extends:
-        deps.append(ctx.attr.extends[TsConfigInfo].deps)
 
     deps.append(_gather_types_from_js_infos([ctx.attr.tsconfig]))
 
@@ -64,7 +57,7 @@ def _gather_tsconfig_deps(ctx):
             if TsConfigInfo in dep
         ])
 
-    return tsconfig, tsconfig_inputs, depset(tsconfig_inputs, transitive = deps)
+    return tsconfig, depset([tsconfig], transitive = deps)
 
 def _ts_project_impl(ctx):
     """Creates the action which spawns `tsc`.
@@ -86,17 +79,16 @@ def _ts_project_impl(ctx):
             fail("srcs of a ts_project should be files not directories")
 
     srcs_inputs = copy_files_to_bin_actions(ctx, ctx.files.srcs)
-    tsconfig, tsconfig_inputs, tsconfig_transitive_deps = _gather_tsconfig_deps(ctx)
+    tsconfig, tsconfig_transitive_deps = _gather_tsconfig_deps(ctx)
 
     srcs = _lib.files_relative_to_package(ctx, srcs_inputs)
 
     srcs_deps = ctx.attr.srcs + ctx.attr.deps
 
-    # tsconfig_inputs are already outputs of copy-to-bin actions (see _gather_tsconfig_deps),
+    # tsconfig_transitive_deps are already outputs of copy-to-bin actions (see _gather_tsconfig_deps),
     # so there is no need to pass them through copy_files_to_bin_actions again.
-    tsc_inputs = srcs_inputs + tsconfig_inputs
-    tsc_inputs_depset = depset(tsc_inputs, transitive = [tsconfig_transitive_deps])
-    tsc_transitive_inputs_depset = depset(tsc_inputs, transitive = [
+    tsc_inputs_depset = depset(srcs_inputs, transitive = [tsconfig_transitive_deps])
+    tsc_transitive_inputs_depset = depset(srcs_inputs, transitive = [
         _gather_types_from_js_infos(srcs_deps),
         tsconfig_transitive_deps,
     ])

--- a/ts/test/ts_config_test.bzl
+++ b/ts/test/ts_config_test.bzl
@@ -89,6 +89,29 @@ def ts_config_test_suite(name):
         tsconfig = ":tsconfig_with_package_json_dep",
     )
 
+    # A ts_config target used as the tsconfig of a ts_project that also passes
+    # `extends`. The macro wraps both in another ts_config, which must not drop
+    # the deps of the tsconfig target it wraps.
+    write_file(
+        name = "src_tsconfig_pkgjson_extending",
+        out = "src_tsconfig_pkgjson_extending.json",
+        content = ["""{"files": ["src_ts.ts"], "compilerOptions": {"declaration": true, "outDir": "pkgjson-extending-outdir"}}"""],
+        tags = ["manual"],
+    )
+    ts_config(
+        name = "tsconfig_with_package_json_dep_extending",
+        src = "src_tsconfig_pkgjson_extending.json",
+        deps = [":src_package_json"],
+    )
+    ts_project(
+        name = "use_tsconfig_target_with_extends",
+        srcs = [":src_ts"],
+        declaration = True,
+        extends = ":tsconfig",
+        out_dir = "pkgjson-extending-outdir",
+        tsconfig = ":tsconfig_with_package_json_dep_extending",
+    )
+
     # ts_config whose src is another ts_config target (mirrors the
     # examples/package_json_usage/parent_src pattern, where a child
     # ts_config consumes a parent ts_config's bin-tree-copied tsconfig.json
@@ -189,6 +212,11 @@ def ts_config_test_suite(name):
         target_under_test = "use_tsconfig_wrapping_ts_config",
     )
 
+    _ts_project_sees_package_json_in_tsc_inputs_test(
+        name = "tsconfig_target_with_extends_test",
+        target_under_test = "use_tsconfig_target_with_extends",
+    )
+
     native.test_suite(
         name = name,
         tests = [
@@ -199,6 +227,7 @@ def ts_config_test_suite(name):
             ":outputs_use_dict_extending_tsconfig_target_test",
             ":tsconfig_with_package_json_dep_test",
             ":tsconfig_wrapping_ts_config_test",
+            ":tsconfig_target_with_extends_test",
         ],
     )
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
