### PR TITLE
fix: validate ts 7+ with tsc--showConfig

### DIFF
--- a/e2e/external_dep/BUILD
+++ b/e2e/external_dep/BUILD
@@ -36,6 +36,37 @@ ts_project(
     composite = True,
     out_dir = "ts7rc_out",
     tsc = "@npm_typescript-7rc//:tsc",
+    validator = "@npm_typescript-7rc//:validator",
+)
+
+# Validation must accept an option implied as a computed default of another
+# (checkJs implies allowJs) without the implied attribute being set. See the
+# composite -> declaration/incremental cases on ':lib' and ':lib.ts7rc'.
+ts_project(
+    name = "implied_checkjs",
+    srcs = ["lib.ts"],
+    out_dir = "implied_checkjs_out",
+    tsconfig = "tsconfig-checkjs.json",
+)
+
+ts_project(
+    name = "implied_checkjs.ts7rc",
+    srcs = ["lib.ts"],
+    out_dir = "implied_checkjs_ts7rc_out",
+    tsc = "@npm_typescript-7rc//:tsc",
+    tsconfig = "tsconfig-checkjs.json",
+    validator = "@npm_typescript-7rc//:validator",
+)
+
+# TypeScript 5.9 resolves `module: nodenext` to also imply resolveJsonModule;
+# the validator must accept resolve_json_module unset.
+ts_project(
+    name = "implied_resolve_json_module",
+    srcs = ["lib.ts"],
+    out_dir = "implied_resolve_json_module_out",
+    tsc = "@npm_typescript-59//:tsc",
+    tsconfig = "tsconfig-nodenext.json",
+    validator = "@npm_typescript-59//:validator",
 )
 
 build_test(
@@ -45,6 +76,9 @@ build_test(
         "lib.ts3",
         "lib.ts56rc",
         "lib.ts7rc",
+        "implied_checkjs",
+        "implied_checkjs.ts7rc",
+        "implied_resolve_json_module",
     ],
 )
 

--- a/e2e/external_dep/MODULE.bazel
+++ b/e2e/external_dep/MODULE.bazel
@@ -31,7 +31,13 @@ rules_ts_ext.deps(
     name = "npm_typescript-7rc",
     ts_version = "7.0.1-rc",
 )
-use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript-7rc", "npm_typescript3")
+
+# TypeScript 5.9, where `module: nodenext` implies resolveJsonModule
+rules_ts_ext.deps(
+    name = "npm_typescript-59",
+    ts_version = "5.9.2",
+)
+use_repo(rules_ts_ext, "npm_typescript", "npm_typescript-56rc", "npm_typescript-59", "npm_typescript-7rc", "npm_typescript3")
 
 bazel_dep(name = "sub_external", version = "0.0.0", dev_dependency = True)
 local_path_override(

--- a/e2e/external_dep/WORKSPACE
+++ b/e2e/external_dep/WORKSPACE
@@ -23,6 +23,11 @@ rules_ts_dependencies(
     ts_version = "7.0.1-rc",
 )
 
+rules_ts_dependencies(
+    name = "npm_typescript-59",
+    ts_version = "5.9.2",
+)
+
 # NOTE: only required on non-bzlmod where the sub_external/WORKSPACE is not loaded to declare npm_typescript2
 rules_ts_dependencies(
     name = "npm_typescript2",

--- a/e2e/external_dep/tsconfig-checkjs.json
+++ b/e2e/external_dep/tsconfig-checkjs.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "checkJs": true
+    }
+}

--- a/e2e/external_dep/tsconfig-nodenext.json
+++ b/e2e/external_dep/tsconfig-nodenext.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "module": "nodenext"
+    }
+}

--- a/e2e/test/common.bats
+++ b/e2e/test/common.bats
@@ -5,6 +5,8 @@ function workspace() {
 	local rules_ts_path="$(realpath $BATS_TEST_DIRNAME/../../)"
 	local -i is_npm_translate_lock=0
 	local -i no_convenience_symlinks=0
+	# TODO(#361): upgrade the default to 5.x
+	local ts_version="4.9.5"
 	while (($# > 0)); do
 		case "$1" in
 		-t | --npm-translate-lock)
@@ -13,6 +15,11 @@ function workspace() {
 			;;
 		-t | --noconvenience-symlinks)
 			no_convenience_symlinks=1
+			shift
+			;;
+		--version)
+			shift
+			ts_version="$1"
 			shift
 			;;
 		*) break ;;
@@ -28,8 +35,7 @@ local_repository(
 
 load("@aspect_rules_ts//ts:repositories.bzl", "rules_ts_dependencies")
 
-# TODO(#361): upgrade to 5.x
-rules_ts_dependencies(ts_version = "4.9.5")
+rules_ts_dependencies(ts_version = "$ts_version")
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
 

--- a/e2e/test/validation.bats
+++ b/e2e/test/validation.bats
@@ -257,3 +257,37 @@ EOF
 	assert_output -p "outDir in the tsconfig resolves to"
 	assert_output -p "which is a parent of the package directory"
 }
+
+@test 'When a native TypeScript (>= 7) project attribute does not match the tsconfig, validation fails' {
+	# The native compiler ships no JS API, so the default validator resolves the
+	# config by spawning its tsc --showConfig rather than the compiler API.
+	workspace --version 7.0.1-rc
+
+	echo "export const a = 1;" >./source.ts
+
+	cat >tsconfig.json <<EOF
+{
+    "compilerOptions": {
+        "composite": true
+    }
+}
+EOF
+
+	cat >BUILD.bazel <<EOF
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "foo",
+    srcs = ["source.ts"],
+    tsconfig = "tsconfig.json",
+    composite = True,
+    out_dir = "out",
+    declaration_map = True,
+)
+EOF
+
+	run bazel build :foo
+	assert_failure
+	assert_output -p 'declaration_map'
+	assert_output -p 'declarationMap'
+}

--- a/ts/private/ts_project_options_validator.cjs
+++ b/ts/private/ts_project_options_validator.cjs
@@ -1,51 +1,59 @@
 'use strict'
 exports.__esModule = true
 var path_1 = require('path')
-var ts = require('typescript')
-var diagnosticsHost = {
-    getCurrentDirectory: function () {
-        return ts.sys.getCurrentDirectory()
-    },
-    getNewLine: function () {
-        return ts.sys.newLine
-    },
-    // Print filenames including their relativeRoot, so they can be located on
-    // disk
-    getCanonicalFileName: function (f) {
-        return f
-    },
+// Resolve the tsconfig "extends" chain to a single config, equivalent to what
+// `tsc --showConfig -p <tsconfig>` prints. Classic TypeScript (< 7) exposes the
+// compiler API to node so this runs in-process; native TypeScript (>= 7) ships no
+// JS API, so the same output is obtained by spawning the compiler CLI instead.
+function resolveConfig(tsconfigPath) {
+    var ts
+    try {
+        ts = require('typescript')
+    } catch (e) {
+        ts = null
+    }
+    if (ts && typeof ts.getParsedCommandLineOfConfigFile === 'function') {
+        return resolveConfigViaApi(ts, tsconfigPath)
+    }
+    return resolveConfigViaShowConfig(tsconfigPath)
 }
-function main(_a) {
-    var _b
-    var tsconfigPath = _a[0],
-        output = _a[1],
-        target = _a[2],
-        packageDir = _a[3],
-        attrsStr = _a[4]
-    // The Bazel ts_project attributes were json-encoded
-    // (on Windows the quotes seem to be quoted wrong, so replace backslash with quotes :shrug:)
-    var attrs = JSON.parse(attrsStr.replace(/\\/g, '"'))
-    // Parse your typescript settings from the tsconfig
-    // This will understand the "extends" semantics.
-    var _c = ts.readConfigFile(tsconfigPath, ts.sys.readFile),
-        config = _c.config,
-        error = _c.error
-    if (error)
-        throw new Error(
-            tsconfigPath + ':' + ts.formatDiagnostic(error, diagnosticsHost)
-        )
-    var _d = ts.parseJsonConfigFileContent(
-            config,
-            ts.sys,
-            path_1.dirname(tsconfigPath)
-        ),
-        errors = _d.errors,
-        options = _d.options
+function resolveConfigViaApi(ts, tsconfigPath) {
+    var diagnosticsHost = {
+        getCurrentDirectory: function () {
+            return ts.sys.getCurrentDirectory()
+        },
+        getNewLine: function () {
+            return ts.sys.newLine
+        },
+        // Print filenames including their relativeRoot, so they can be located on
+        // disk
+        getCanonicalFileName: function (f) {
+            return f
+        },
+    }
+    var host = {
+        fileExists: ts.sys.fileExists,
+        readFile: ts.sys.readFile,
+        readDirectory: ts.sys.readDirectory,
+        getCurrentDirectory: function () {
+            return ts.sys.getCurrentDirectory()
+        },
+        useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+        onUnRecoverableConfigFileDiagnostic: function (d) {
+            throw new Error(
+                tsconfigPath + ':' + ts.formatDiagnostic(d, diagnosticsHost)
+            )
+        },
+    }
+    var parsed = ts.getParsedCommandLineOfConfigFile(
+        tsconfigPath,
+        undefined,
+        host
+    )
     // We don't pass the srcs to this action, so it can't know if the program has the right sources.
-    // Diagnostics look like
     // error TS18002: The 'files' list in config file 'tsconfig.json' is empty.
     // error TS18003: No inputs were found in config file 'tsconfig.json'. Specified 'include'...
-    var fatalErrors = errors.filter(function (e) {
+    var fatalErrors = parsed.errors.filter(function (e) {
         return e.code !== 18002 && e.code !== 18003
     })
     if (fatalErrors.length > 0)
@@ -54,25 +62,119 @@ function main(_a) {
                 ':' +
                 ts.formatDiagnostics(fatalErrors, diagnosticsHost)
         )
+    var config = ts.convertToTSConfig(parsed, tsconfigPath, ts.sys)
+    relativizeConfigPaths(config, tsconfigPath)
+    // Only keep "files" when the original config specified it; a glob-based config
+    // resolves it from this action's inputs (the tsconfig chain, not the srcs).
+    if (!Array.isArray(parsed.raw && parsed.raw.files)) delete config.files
+    return JSON.parse(JSON.stringify(config))
+}
+function resolveConfigViaShowConfig(tsconfigPath) {
+    // require('typescript') is blocked by the native package's exports map, but
+    // ./package.json is always resolvable; anchor the compiler CLI on it.
+    var tscBin = path_1.join(
+        path_1.dirname(require.resolve('typescript/package.json')),
+        'bin',
+        'tsc'
+    )
+    var stdout = require('child_process').execFileSync(
+        process.execPath,
+        [tscBin, '--project', tsconfigPath, '--showConfig'],
+        { encoding: 'utf-8' }
+    )
+    var config = JSON.parse(stdout)
+    relativizeConfigPaths(config, tsconfigPath)
+    // "files" is resolved from this action's inputs, not the compile, and is never
+    // validated, so drop it.
+    delete config.files
+    return JSON.parse(JSON.stringify(config))
+}
+// tsc materializes some paths as absolute, e.g. the implicit exclusion of outDir.
+// Absolute paths under the execroot are not hermetic (sandbox paths differ across
+// builds), so turn them back into paths relative to the config file.
+// cwd is BAZEL_BINDIR (bazel-out/<config>/bin), three segments below the execroot.
+function relativizeConfigPaths(config, tsconfigPath) {
+    var configDir = path_1.dirname(path_1.resolve(tsconfigPath))
+    var execroot = path_1.resolve(process.cwd(), '..', '..', '..')
+    function relativize(p) {
+        if (
+            typeof p !== 'string' ||
+            !path_1.isAbsolute(p) ||
+            !p.startsWith(execroot + path_1.sep)
+        ) {
+            return p
+        }
+        var rel = path_1.relative(configDir, p)
+        return rel.startsWith('..') ? rel : './' + rel
+    }
+    var arrayKeys = ['files', 'include', 'exclude']
+    for (var i = 0; i < arrayKeys.length; i++) {
+        var key = arrayKeys[i]
+        if (Array.isArray(config[key])) {
+            config[key] = config[key].map(relativize)
+        }
+    }
+    if (Array.isArray(config.references)) {
+        config.references = config.references.map(function (r) {
+            return Object.assign({}, r, { path: relativize(r.path) })
+        })
+    }
+    if (config.compilerOptions) {
+        for (var option in config.compilerOptions) {
+            var value = config.compilerOptions[option]
+            if (typeof value === 'string') {
+                config.compilerOptions[option] = relativize(value)
+            } else if (Array.isArray(value)) {
+                config.compilerOptions[option] = value.map(relativize)
+            }
+        }
+    }
+}
+function main(_a) {
+    var tsconfigPath = _a[0],
+        output = _a[1],
+        target = _a[2],
+        packageDir = _a[3],
+        attrsStr = _a[4]
+    // The Bazel ts_project attributes were json-encoded
+    // (on Windows the quotes seem to be quoted wrong, so replace backslash with quotes :shrug:)
+    var attrs = JSON.parse(attrsStr.replace(/\\/g, '"'))
+    // The resolved config, in `tsc --showConfig` shape. The checks below read this
+    // JSON only, so they run identically whether it was resolved in-process or by
+    // the native compiler CLI.
+    var config = resolveConfig(tsconfigPath)
+    var options = config.compilerOptions || {}
+    var configDir = path_1.dirname(path_1.resolve(tsconfigPath))
     var failures = []
     var buildozerCmds = []
     function getTsOption(option) {
         if (typeof options[option] === 'string') {
             // Currently the only string-typed options are filepaths.
-            // TypeScript will resolve these to a project path
-            // so when echoing that back to the user, we need to reverse that resolution.
-            return path_1.relative(packageDir, options[option])
+            // The resolved config states these relative to the config file, so when
+            // echoing that back to the user, re-state them relative to the package.
+            return path_1.relative(
+                packageDir,
+                path_1.resolve(configDir, options[option])
+            )
         }
         return options[option]
     }
-    function check(option, attr) {
+    function check(option, attr, isImplied) {
         attr = attr || option
         // treat compilerOptions undefined as false
         var optionVal = getTsOption(option)
         var match =
             optionVal === attrs[attr] ||
             (optionVal === undefined &&
-                (attrs[attr] === false || attrs[attr] === ''))
+                (attrs[attr] === false || attrs[attr] === '')) ||
+            // The resolved config materializes options implied as computed defaults of
+            // other options, e.g. composite implies declaration and incremental,
+            // checkJs implies allowJs, and `module: nodenext` implies resolveJsonModule.
+            // The attribute only needs to match what the tsconfig configures explicitly.
+            (isImplied !== undefined &&
+                optionVal === true &&
+                attrs[attr] === false &&
+                isImplied())
         if (!match) {
             failures.push(
                 'attribute ' +
@@ -151,7 +253,7 @@ function main(_a) {
         // The boundary is the rule's package, not the tsconfig's directory:
         // tsconfigs may live in subfolders (e.g. pkg/config/tsconfig.json) where
         // ".." still resolves inside the package.
-        var rel = path_1.relative(packageDir, optionVal)
+        var rel = path_1.relative(packageDir, path_1.resolve(configDir, optionVal))
 
         if (rel === '..' || rel.startsWith('../') || rel.startsWith('..\\')) {
             throw new Error(
@@ -173,32 +275,22 @@ function main(_a) {
             )
         }
     }
-    var jsxEmit =
-        ((_b = {}),
-        (_b[ts.JsxEmit.None] = 'none'),
-        (_b[ts.JsxEmit.Preserve] = 'preserve'),
-        (_b[ts.JsxEmit.React] = 'react'),
-        (_b[ts.JsxEmit.ReactNative] = 'react-native'),
-        (_b[ts.JsxEmit.ReactJSX] = 'react-jsx'),
-        (_b[ts.JsxEmit.ReactJSXDev] = 'react-jsx-dev'),
-        _b)
     function check_preserve_jsx() {
         var attr = 'preserve_jsx'
+        // The resolved config states enum options as their string form, e.g. "preserve".
         var jsxVal = options['jsx']
-        if ((jsxVal === ts.JsxEmit.Preserve) !== Boolean(attrs[attr])) {
+        var isPreserve = jsxVal === 'preserve'
+        if (isPreserve !== Boolean(attrs[attr])) {
             failures.push(
                 'attribute ' +
                     attr +
                     '=' +
                     attrs[attr] +
                     ' does not match compilerOptions.jsx=' +
-                    jsxEmit[jsxVal]
+                    jsxVal
             )
             buildozerCmds.push(
-                'set ' +
-                    attr +
-                    ' ' +
-                    (jsxVal === ts.JsxEmit.Preserve ? 'True' : 'False')
+                'set ' + attr + ' ' + (isPreserve ? 'True' : 'False')
             )
         }
     }
@@ -224,15 +316,28 @@ function main(_a) {
         )
         return 1
     }
-    check('allowJs', 'allow_js')
+    var impliedByComposite = function () {
+        return options['composite'] === true && attrs['composite'] === true
+    }
+    check('allowJs', 'allow_js', function () {
+        return options['checkJs'] === true
+    })
     check('declarationMap', 'declaration_map')
     check('noEmit', 'no_emit')
     check('emitDeclarationOnly', 'emit_declaration_only')
-    check('resolveJsonModule', 'resolve_json_module')
+    check('resolveJsonModule', 'resolve_json_module', function () {
+        var moduleKind = String(options['module']).toLowerCase()
+        var moduleResolution = String(options['moduleResolution']).toLowerCase()
+        return (
+            ['node16', 'node18', 'node20', 'nodenext', 'preserve'].indexOf(
+                moduleKind
+            ) !== -1 || moduleResolution === 'bundler'
+        )
+    })
     check('sourceMap', 'source_map')
     check('composite')
-    check('declaration')
-    check('incremental')
+    check('declaration', undefined, impliedByComposite)
+    check('incremental', undefined, impliedByComposite)
     check('tsBuildInfoFile', 'ts_build_info_file')
     // Must run before check_out_dir to win over its less specific attr-mismatch error.
     checkDirInParent('rootDir', 'root_dir')


### PR DESCRIPTION
Close https://github.com/aspect-build/rules_ts/pull/962 which had an alternative approach.
Ref https://github.com/aspect-build/rules_ts/pull/950 or https://github.com/aspect-build/rules_ts/pull/967 which do all validation (not only >=7.x) this way in rules_ts 4.x

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`ts_project` attribute vs tsconfig validation for ts v7+ is now done using `tsc --showConfig`. This may catch additional validation errors not previously found such as when tsconfigs extend from npm packages.

### Test plan

- Covered by existing test cases
- New test cases added
