### PR TITLE
chore: run ci workflows on 3.x in addition to main

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -2,9 +2,9 @@ name: CI - Aspect Workflows
 
 on:
     push:
-        branches: [main]
+        branches: [main, 2.x, 3.x]
     pull_request:
-        branches: [main]
+        branches: [main, 2.x, 3.x]
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
