### PR TITLE
fix: relativize absolute paths in resolved tsconfigs on windows

### DIFF
--- a/ts/private/ts_project_options_validator.cjs
+++ b/ts/private/ts_project_options_validator.cjs
@@ -56,16 +56,20 @@ function resolveConfig(tsconfigPath, output) {
 // cwd is BAZEL_BINDIR (bazel-out/<config>/bin), three segments below the execroot.
 function relativizeConfigPaths(config, tsconfigPath) {
     var configDir = path_1.dirname(path_1.resolve(tsconfigPath))
-    var execroot = path_1.resolve(process.cwd(), '..', '..', '..')
+    // tsc prints paths with forward slashes on all platforms; compare and emit
+    // forward slashes so windows behaves identically.
+    var execroot = path_1
+        .resolve(process.cwd(), '..', '..', '..')
+        .replace(/\\/g, '/')
     function relativize(p) {
         if (
             typeof p !== 'string' ||
             !path_1.isAbsolute(p) ||
-            !p.startsWith(execroot + path_1.sep)
+            !p.startsWith(execroot + '/')
         ) {
             return p
         }
-        var rel = path_1.relative(configDir, p)
+        var rel = path_1.relative(configDir, p).replace(/\\/g, '/')
         return rel.startsWith('..') ? rel : './' + rel
     }
     var arrayKeys = ['files', 'include', 'exclude']

--- a/ts/test/implicit_exclude.resolved.tsconfig.golden
+++ b/ts/test/implicit_exclude.resolved.tsconfig.golden
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "outDir": "./implicit_exclude_out"
+    },
+    "exclude": [
+        "./implicit_exclude_out"
+    ]
+}

--- a/ts/test/ts_project_test.bzl
+++ b/ts/test/ts_project_test.bzl
@@ -184,6 +184,42 @@ def ts_project_test_suite(name):
         file2 = ":dir_validation_output",
     )
 
+    # When "exclude" is unspecified, tsc materializes the implicit exclusion of outDir
+    # as an ABSOLUTE path, which the validator must relativize for hermetic output.
+    # The golden pins that relativization, including on windows where tsc prints
+    # forward-slash absolute paths.
+    write_file(
+        name = "implicit_exclude_ts",
+        out = "implicit_exclude.ts",
+        content = ["export const a = 1"],
+        tags = ["manual"],
+    )
+    write_file(
+        name = "tsconfig_implicit_exclude",
+        out = "tsconfig_implicit_exclude.json",
+        content = ['{"compilerOptions": {"declaration": true, "outDir": "implicit_exclude_out"}, "files": ["implicit_exclude.ts"]}'],
+        tags = ["manual"],
+    )
+    ts_project(
+        name = "implicit_exclude",
+        srcs = [":implicit_exclude_ts"],
+        declaration = True,
+        out_dir = "implicit_exclude_out",
+        tsconfig = ":tsconfig_implicit_exclude",
+        tags = ["manual"],
+    )
+    native.filegroup(
+        name = "implicit_exclude_validation_output",
+        srcs = [":implicit_exclude"],
+        output_group = "_validation",
+        tags = ["manual"],
+    )
+    diff_test(
+        name = "implicit_exclude_resolved_tsconfig_test",
+        file1 = "implicit_exclude.resolved.tsconfig.golden",
+        file2 = ":implicit_exclude_validation_output",
+    )
+
     write_file(
         name = "use_dir_ts",
         out = "use_dir.ts",


### PR DESCRIPTION
Extra path manipulation for windows, in addition to https://github.com/aspect-build/rules_ts/pull/973 which fixed `main`.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
