### PR TITLE
refactor: capture isolated typecheck stderr via spawn_binary

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.19.2")
+bazel_dep(name = "bazel_lib", version = "3.5.0")
 bazel_dep(name = "aspect_tools_telemetry", version = "0.4.2")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "aspect_rules_js", version = "2.3.8")
 bazel_dep(name = "aspect_rules_ts")
-bazel_dep(name = "bazel_lib", version = "3.1.0")
+bazel_dep(name = "bazel_lib", version = "3.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "protobuf", version = "33.4")
 

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -13,6 +13,8 @@ load(":ts_config.bzl", "TsConfigInfo")
 load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS", "OUTPUT_ATTRS", "STD_ATTRS", _lib = "lib")
 load(":ts_validate_options.bzl", _validate_lib = "lib")
 
+SPAWN_BINARY_TOOLCHAIN_TYPE = "@bazel_lib//lib:spawn_binary_toolchain_type"
+
 # Forked from js_lib_helpers.js_lib_helpers.gather_files_from_js_providers to not
 # include any sources; only transitive types & npm sources
 def _gather_types_from_js_infos(targets):
@@ -302,15 +304,30 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             tsconfig_path = tsconfig_path,
         )
 
+        # All we care about is whether this action succeeded or not, but Bazel
+        # requires every action to have an output. Wrap the invocation in
+        # bazel_lib's spawn_binary to capture stderr into an output file. We
+        # capture stderr rather than stdout so that tsc's diagnostics still
+        # reach the console when type-checking fails.
+        spawn_binary_toolchain = ctx.toolchains[SPAWN_BINARY_TOOLCHAIN_TYPE]
+        if not spawn_binary_toolchain:
+            fail("ts_project target {} requires the spawn_binary toolchain.".format(ctx.label))
+        wrapper_arguments = ctx.actions.args()
+        wrapper_arguments.add("--stderr", typecheck_output)
+        wrapper_arguments.add("--")
+        wrapper_arguments.add(executable)
+
         ctx.actions.run(
-            executable = executable,
+            executable = spawn_binary_toolchain.spawn_binary_info.bin,
             inputs = tsc_transitive_inputs_depset,
-            arguments = [typecheck_arguments],
+            tools = [ctx.attr.tsc[DefaultInfo].files_to_run],
+            arguments = [wrapper_arguments, typecheck_arguments],
             outputs = typecheck_outputs,
             mnemonic = "TsProjectCheck",
             execution_requirements = execution_requirements,
             resource_set = resource_set(ctx.attr),
             progress_message = progress_message,
+            toolchain = SPAWN_BINARY_TOOLCHAIN_TYPE,
             env = env,
         )
     else:
@@ -452,5 +469,7 @@ ts_project = rule(
     """,
     implementation = lib.implementation,
     attrs = lib.attrs,
-    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS + [
+        config_common.toolchain_type(SPAWN_BINARY_TOOLCHAIN_TYPE, mandatory = False),
+    ],
 )


### PR DESCRIPTION
Bazel requires every action to have at least one output, so the isolated typcheck action captures tsc's stderr into a marker file. This previously relied on JS_BINARY__STDOUT_OUTPUT_FILE, a private env var understood only by js_binary's launcher. Use bazel_lib's spawn_binary toolchain instead, the same mechanism run_binary's `stdout` and `stderr` attributes use. Requires bumping the bazel_lib minimum version to 3.5.0.

The reason we start capturing `stderr` instead of `stdout` is that `spawn_binary` will not print out any output that it is capturing. If type checking fails then we want to be able to know the reason, so it's important for `stdout` to printed out. `stderr` is not especially interesting, but Bazel requires every action to output something.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
