### PR TITLE
fix: complete aspect_bazel_lib to bazel_lib migration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,11 +6,16 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.19.2")
+bazel_dep(name = "bazel_lib", version = "3.1.0")
 bazel_dep(name = "aspect_tools_telemetry", version = "0.4.2")
-bazel_dep(name = "aspect_rules_js", version = "2.0.0")
+bazel_dep(name = "aspect_rules_js", version = "2.8.1")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "0.0.5")
+
+# aspect_rules_js still uses aspect_bazel_lib (the pre-rename module) internally
+# for some of its helpers; bump the floor past the version where its bzlmod
+# toolchain registration was fixed.
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5", repo_name = None)
 
 # TODO(4.x): remove support for non-toolchainized protoc
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")

--- a/e2e/smoke/WORKSPACE
+++ b/e2e/smoke/WORKSPACE
@@ -85,8 +85,49 @@ load("@npm//:repositories.bzl", "npm_repositories")
 
 npm_repositories()
 
-# Register aspect_bazel_lib toolchains;
-# If you use npm_translate_lock or npm_import from aspect_rules_js you can omit this block.
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+load(
+    "@bazel_lib//lib:repositories.bzl",
+    "bazel_lib_dependencies",
+    "register_bats_toolchains",
+    "register_copy_directory_toolchains",
+    "register_copy_to_directory_toolchains",
+    "register_coreutils_toolchains",
+    "register_expand_template_toolchains",
+    "register_zstd_toolchains",
+)
 
-aspect_bazel_lib_dependencies()
+# Required bazel-lib dependencies
+bazel_lib_dependencies()
+
+# Required rules_shell dependencies
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
+# Register bazel-lib toolchains. rules_js_register_toolchains() above already
+# registers copy_directory/copy_to_directory/coreutils toolchains from the
+# legacy aspect_bazel_lib (still used internally by aspect_rules_js), so
+# register bazel_lib's versions under distinct repo names to avoid colliding
+# with those, rather than calling bazel_lib_register_toolchains() directly.
+register_copy_directory_toolchains(name = "bazel_lib_copy_directory")
+
+register_copy_to_directory_toolchains(name = "bazel_lib_copy_to_directory")
+
+register_coreutils_toolchains(name = "bazel_lib_coreutils")
+
+register_expand_template_toolchains()
+
+register_zstd_toolchains()
+
+register_bats_toolchains()
+
+# Create the host platform repository transitively required by bazel-lib
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+    host_platform_repo,
+    name = "host_platform",
+)

--- a/e2e/test/common.bats
+++ b/e2e/test/common.bats
@@ -45,9 +45,20 @@ load("@aspect_rules_js//js:toolchains.bzl", "DEFAULT_NODE_VERSION", "rules_js_re
 
 rules_js_register_toolchains(node_version = DEFAULT_NODE_VERSION)
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "register_copy_directory_toolchains", "register_copy_to_directory_toolchains")
-register_copy_directory_toolchains()
-register_copy_to_directory_toolchains()
+load(
+    "@bazel_lib//lib:repositories.bzl",
+    "register_copy_directory_toolchains",
+    "register_copy_to_directory_toolchains",
+    "register_coreutils_toolchains",
+)
+
+# rules_js_register_toolchains() above already registers copy_directory/
+# copy_to_directory/coreutils toolchains from the legacy aspect_bazel_lib
+# (still used internally by aspect_rules_js), so register bazel_lib's
+# versions under distinct repo names to avoid colliding with those.
+register_copy_directory_toolchains(name = "bazel_lib_copy_directory")
+register_copy_to_directory_toolchains(name = "bazel_lib_copy_to_directory")
+register_coreutils_toolchains(name = "bazel_lib_coreutils")
 EOF
 
 	[[ -e "$BATS_TEST_DIRNAME/.bazelversion" ]] && cp "$BATS_TEST_DIRNAME/.bazelversion" .bazelversion

--- a/e2e/test/dir_as_source.bats
+++ b/e2e/test/dir_as_source.bats
@@ -18,7 +18,7 @@ teardown() {
 
 	cat >>BUILD.bazel <<EOF
 
-load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
+load("@bazel_lib//lib:copy_directory.bzl", "copy_directory")
 
 copy_directory(
     name = "code_generation",

--- a/e2e/worker/BUILD
+++ b/e2e/worker/BUILD
@@ -1,5 +1,5 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 

--- a/e2e/worker/MODULE.bazel
+++ b/e2e/worker/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.20.0", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.1.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 

--- a/e2e/worker/composite/BUILD.bazel
+++ b/e2e/worker/composite/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 package(default_visibility = ["//composite:__subpackages__"])
 

--- a/ts/BUILD.bazel
+++ b/ts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
+load("@bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("//ts/private:options.bzl", "options")
@@ -139,9 +139,9 @@ bzl_library(
         "//ts/private:options",
         "//ts/private:ts_config",
         "//ts/private:ts_project",
-        "@aspect_bazel_lib//lib:utils",
         "@aspect_rules_js//js:defs",
         "@aspect_tools_telemetry_report//:defs.bzl",
+        "@bazel_lib//lib:utils",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//rules:build_test",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
@@ -187,13 +187,13 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//ts/private:ts_proto_library",
-        "@aspect_bazel_lib//lib:copy_to_directory",
-        "@aspect_bazel_lib//lib:directory_path",
-        "@aspect_bazel_lib//lib:platform_utils",
-        "@aspect_bazel_lib//lib:write_source_files",
         "@aspect_rules_js//js:defs",
         "@aspect_rules_js//js:libs",
         "@aspect_rules_js//js:providers",
+        "@bazel_lib//lib:copy_to_directory",
+        "@bazel_lib//lib:directory_path",
+        "@bazel_lib//lib:platform_utils",
+        "@bazel_lib//lib:write_source_files",
     ] + (["@bazel_tools//tools/build_defs/repo:cache.bzl"] if bazel_lib_utils.is_bazel_7_or_greater() else []),
 )
 

--- a/ts/BUILD.typescript
+++ b/ts/BUILD.typescript
@@ -1,9 +1,9 @@
 "BUILD file inserted into @npm_typescript repository"
 
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
 load("@aspect_rules_js//npm/private:npm_package_internal.bzl", "npm_package_internal")
+load("@bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")

--- a/ts/defs.bzl
+++ b/ts/defs.bzl
@@ -4,8 +4,8 @@ The most commonly used is the [ts_project](#function-ts_project) macro which acc
 inputs and produces JavaScript or declaration (.d.ts) outputs.
 """
 
-load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@aspect_tools_telemetry_report//:defs.bzl", "TELEMETRY")  # buildifier: disable=load
+load("@bazel_lib//lib:utils.bzl", "to_label")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("//ts/private:build_test.bzl", "build_test")
 load("//ts/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")

--- a/ts/private/BUILD.bazel
+++ b/ts/private/BUILD.bazel
@@ -23,10 +23,10 @@ bzl_library(
     visibility = ["//ts:__subpackages__"],
     deps = [
         ":ts_lib",
-        "@aspect_bazel_lib//lib:copy_to_bin",
-        "@aspect_bazel_lib//lib:paths",
         "@aspect_rules_js//js:libs",
         "@aspect_rules_js//js:providers",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:paths",
     ],
 )
 
@@ -49,14 +49,14 @@ bzl_library(
         ":ts_config",
         ":ts_lib",
         ":ts_validate_options",
-        "@aspect_bazel_lib//lib:copy_file",
-        "@aspect_bazel_lib//lib:copy_to_bin",
-        "@aspect_bazel_lib//lib:paths",
-        "@aspect_bazel_lib//lib:platform_utils",
-        "@aspect_bazel_lib//lib:resource_sets",
         "@aspect_rules_js//js:libs",
         "@aspect_rules_js//js:providers",
         "@aspect_rules_js//npm:providers",
+        "@bazel_lib//lib:copy_file",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:paths",
+        "@bazel_lib//lib:platform_utils",
+        "@bazel_lib//lib:resource_sets",
         "@bazel_skylib//lib:dicts",
     ],
 )
@@ -68,9 +68,9 @@ bzl_library(
     deps = [
         ":ts_config",
         ":ts_lib",
-        "@aspect_bazel_lib//lib:copy_to_bin",
-        "@aspect_bazel_lib//lib:paths",
         "@aspect_rules_js//js:providers",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:paths",
     ],
 )
 
@@ -79,7 +79,8 @@ bzl_library(
     srcs = ["ts_proto_library.bzl"],
     visibility = ["//ts:__subpackages__"],
     deps = [
-        "@bazel_skylib//lib:paths",
+        "@bazel_lib//lib:copy_to_bin",
+        "@bazel_lib//lib:platform_utils",
         "@rules_proto//proto:defs",
     ],
 )

--- a/ts/private/ts_config.bzl
+++ b/ts/private/ts_config.bzl
@@ -14,10 +14,10 @@
 
 "tsconfig.json files using extends"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
-load("@aspect_bazel_lib//lib:paths.bzl", "relative_file")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "js_info")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
+load("@bazel_lib//lib:paths.bzl", "relative_file")
 load(":ts_lib.bzl", _lib = "lib")
 
 TsConfigInfo = provider(

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -1,12 +1,12 @@
 "ts_project rule"
 
-load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file_action")
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
-load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
-load("@aspect_bazel_lib//lib:platform_utils.bzl", "platform_utils")
-load("@aspect_bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
+load("@bazel_lib//lib:copy_file.bzl", "copy_file_action")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
+load("@bazel_lib//lib:paths.bzl", "to_output_relative_path")
+load("@bazel_lib//lib:platform_utils.bzl", "platform_utils")
+load("@bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":options.bzl", "OptionsInfo", "transpiler_selection_required")
 load(":ts_config.bzl", "TsConfigInfo")

--- a/ts/private/ts_proto_library.bzl
+++ b/ts/private/ts_proto_library.bzl
@@ -1,7 +1,7 @@
 "Private implementation details for ts_proto_library"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
-load("@aspect_bazel_lib//lib:platform_utils.bzl", "platform_utils")
+load("@bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
+load("@bazel_lib//lib:platform_utils.bzl", "platform_utils")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo", "proto_common")
 load("@rules_proto//proto:proto_common.bzl", proto_toolchains = "toolchains")
 

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -1,6 +1,6 @@
 "Helper rule to check that ts_project attributes match tsconfig.json properties"
 
-load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
+load("@bazel_lib//lib:paths.bzl", "to_output_relative_path")
 load(":ts_lib.bzl", _lib = "lib")
 
 def _validate_action(ctx, tsconfig, tsconfig_deps):

--- a/ts/proto.bzl
+++ b/ts/proto.bzl
@@ -40,10 +40,10 @@ Future work
 - Allow users to control the output format. Currently it is hard-coded to `js+dts`, and the JS output uses ES Modules.
 """
 
-load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path", "make_directory_path")
-load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
+load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_lib//lib:directory_path.bzl", "directory_path", "make_directory_path")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("//ts/private:ts_proto_library.bzl", ts_proto_library_rule = "ts_proto_library")
 
 def ts_proto_library(name, node_modules, proto, protoc_gen_options = {}, gen_connect_es = False, gen_connect_query = False, gen_connect_query_service_mapping = {}, copy_files = True, proto_srcs = None, files_to_copy = None, **kwargs):

--- a/ts/repositories.bzl
+++ b/ts/repositories.bzl
@@ -29,17 +29,17 @@ def rules_ts_bazel_dependencies():
     )
 
     http_archive(
-        name = "aspect_bazel_lib",
-        sha256 = "40ba9d0f62deac87195723f0f891a9803a7b720d7b89206981ca5570ef9df15b",
-        strip_prefix = "bazel-lib-2.14.0",
-        url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz",
+        name = "bazel_lib",
+        integrity = "sha256-/Q/k35treDfV/XZcBP/OpGJTCgiz2YYn+2vmKmk/ThI=",
+        strip_prefix = "bazel-lib-3.1.0",
+        url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.1.0/bazel-lib-v3.1.0.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "6b7e73c35b97615a09281090da3645d9f03b2a09e8caa791377ad9022c88e2e6",
-        strip_prefix = "rules_js-2.0.0",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0/rules_js-v2.0.0.tar.gz",
+        integrity = "sha256-bkY3pjrL0soID0Y8sY/A10OfJAGtv+ACjz9FRMnrgIU=",
+        strip_prefix = "rules_js-2.8.1",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v2.8.1/rules_js-v2.8.1.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
MODULE.bazel still declared the old aspect_bazel_lib module even though ts/*.bzl had already switched to loading from @bazel_lib, so nothing resolved. bazel_lib only exists from v3.0.0 onward in the registry, so the stale 2.x version pins in examples/ and e2e/worker/ were also invalid. aspect_rules_js needed bumping to 2.8.1 (root MODULE.bazel and ts/repositories.bzl's WORKSPACE-mode fetch) since 2.0.0 still hardcodes aspect_bazel_lib internally; a floor on aspect_bazel_lib itself is kept since aspect_rules_js still depends on it transitively. In WORKSPACE mode (e2e/smoke, e2e/test), aspect_rules_js's own toolchain registration collides with bazel_lib's under the same repo names, so bazel_lib's toolchains are now registered under distinct names. Also fixes an unrelated pre-existing bug where ts_proto_library's bzl_library target was missing deps that ts_proto_library.bzl actually loads.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
