### PR TITLE
feat: support path mapping in ts_project when possible

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -44,6 +44,7 @@ jobs:
                 - { path: "examples", slug: "examples" }
                 - { path: "e2e/smoke", slug: "e2e-smoke" }
                 - { path: "e2e/smoke_rjs3", slug: "e2e-smoke_rjs3" }
+                - { path: "e2e/path_mapping", slug: "e2e-path_mapping" }
                 - { path: "e2e/bzlmodules", slug: "e2e-bzlmodules" }
                 - { path: "e2e/nested_repos", slug: "e2e-nested_repos" }
                 - { path: "e2e/external_dep", slug: "e2e-external_dep" }
@@ -61,6 +62,7 @@ jobs:
                 - { workspace: { slug: "examples" }, bazel: { id: "bazel-7-wksp" } }
                 # No WORKSPACE in rules_js v3
                 - { workspace: { slug: "e2e-smoke_rjs3" }, bazel: { id: "bazel-7-wksp" } }
+                - { workspace: { slug: "e2e-path_mapping" }, bazel: { id: "bazel-7-wksp" } }
                 # bzlmod-only test
                 - { workspace: { slug: "e2e-bzlmodules" }, bazel: { id: "bazel-7-wksp" } }
                 - { workspace: { slug: "e2e-nested_repos" }, bazel: { id: "bazel-7-wksp" } }
@@ -75,3 +77,11 @@ jobs:
             - name: Test
               working-directory: ${{ matrix.workspace.path }}
               run: aspect test --task-key=test-${{ matrix.workspace.slug }}-${{ matrix.bazel.id }} ${{ matrix.bazel.flags }} -- //...
+            - name: Optional ./test.sh
+              working-directory: ${{ matrix.workspace.path }}
+              run: |
+                  if [[ -f ./test.sh ]]; then
+                      ./test.sh
+                  else
+                      echo "No test.sh in ${PWD}; skipping"
+                  fi

--- a/e2e/path_mapping/.bazelrc
+++ b/e2e/path_mapping/.bazelrc
@@ -1,0 +1,16 @@
+import %workspace%/../../tools/preset.bazelrc
+
+common --@aspect_rules_ts//ts:skipLibCheck=always
+common --@aspect_rules_ts//ts:default_to_tsc_transpiler
+
+# Path mapping:
+# https://bazel.build/reference/command-line-reference#flag--experimental_output_paths
+common --experimental_output_paths=strip
+
+# Build without the bytes
+common:ci --remote_download_outputs=minimal
+common:ci --nobuild_runfile_links
+
+# Override the preset's `--lockfile_mode=error` on CI since we don't
+# yet commit MODULE.bazel.lock — see .gitignore.
+common:ci --lockfile_mode=off

--- a/e2e/path_mapping/.bazelversion
+++ b/e2e/path_mapping/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/path_mapping/BUILD.bazel
+++ b/e2e/path_mapping/BUILD.bazel
@@ -14,6 +14,18 @@ ts_project(
     tsconfig = ":tsconfig",
 )
 
+# A second target whose isolated typecheck action (mnemonic TsProjectCheck) we
+# can exercise separately from the "lib" target's main TsProject action.
+ts_project(
+    name = "lib_isolated_typecheck",
+    srcs = ["lib.ts"],
+    declaration = True,
+    isolated_typecheck = True,
+    out_dir = "isolated_typecheck",
+    source_map = True,
+    tsconfig = ":tsconfig",
+)
+
 # Gives the `bazel test //...` step in CI something to run; the actual test
 # assertions live in test.sh, which is run as a separate CI step.
 build_test(
@@ -21,5 +33,7 @@ build_test(
     targets = [
         ":lib",
         ":lib_types",
+        ":lib_isolated_typecheck",
+        ":lib_isolated_typecheck_types",
     ],
 )

--- a/e2e/path_mapping/BUILD.bazel
+++ b/e2e/path_mapping/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+)
+
+ts_project(
+    name = "lib",
+    srcs = ["lib.ts"],
+    declaration = True,
+    source_map = True,
+    tsconfig = ":tsconfig",
+)
+
+# Gives the `bazel test //...` step in CI something to run; the actual test
+# assertions live in test.sh, which is run as a separate CI step.
+build_test(
+    name = "test",
+    targets = [
+        ":lib",
+        ":lib_types",
+    ],
+)

--- a/e2e/path_mapping/MODULE.bazel
+++ b/e2e/path_mapping/MODULE.bazel
@@ -8,15 +8,7 @@ local_path_override(
     path = "../..",
 )
 
-# js_binary_lib.run_binary_action, which ts_project opportunistically uses to support path
-# mapping, has not yet been released. This pins to a commit on an unmerged aspect_rules_js
-# branch that has it, for testing purposes only.
-bazel_dep(name = "aspect_rules_js", version = "3.0.2")
-git_override(
-    module_name = "aspect_rules_js",
-    commit = "821502f7b994e8dd9c8fb614121478d1c25f97d9",
-    remote = "https://github.com/aspect-build/rules_js.git",
-)
+bazel_dep(name = "aspect_rules_js", version = "3.4.0")
 
 bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
 

--- a/e2e/path_mapping/MODULE.bazel
+++ b/e2e/path_mapping/MODULE.bazel
@@ -1,0 +1,27 @@
+"Basic e2e test for ts_project path mapping support"
+
+module(name = "e2e_path_mapping")
+
+bazel_dep(name = "aspect_rules_ts", version = "0.0.0")
+local_path_override(
+    module_name = "aspect_rules_ts",
+    path = "../..",
+)
+
+# js_binary_lib.run_binary_action, which ts_project opportunistically uses to support path
+# mapping, has not yet been released. This pins to a commit on an unmerged aspect_rules_js
+# branch that has it, for testing purposes only.
+bazel_dep(name = "aspect_rules_js", version = "3.0.2")
+git_override(
+    module_name = "aspect_rules_js",
+    commit = "821502f7b994e8dd9c8fb614121478d1c25f97d9",
+    remote = "https://github.com/aspect-build/rules_js.git",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
+
+typescript = use_extension("@aspect_rules_ts//ts:extensions.bzl", "typescript")
+typescript.deps(
+    version_from = "//:package.json",
+)
+use_repo(typescript, "npm_typescript")

--- a/e2e/path_mapping/WORKSPACE
+++ b/e2e/path_mapping/WORKSPACE
@@ -1,0 +1,1 @@
+# EMPTY - this test is designed for bzlmod only

--- a/e2e/path_mapping/WORKSPACE
+++ b/e2e/path_mapping/WORKSPACE
@@ -1,1 +1,0 @@
-# EMPTY - this test is designed for bzlmod only

--- a/e2e/path_mapping/lib.ts
+++ b/e2e/path_mapping/lib.ts
@@ -1,0 +1,3 @@
+export function greet(name: string): string {
+    return `Hello, ${name}!`
+}

--- a/e2e/path_mapping/package.json
+++ b/e2e/path_mapping/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "e2e_path_mapping",
+    "version": "1.0.0",
+    "private": true,
+    "packageManager": "pnpm@10.14.0",
+    "dependencies": {
+        "typescript": "5.8.3"
+    },
+    "pnpm": {
+        "onlyBuiltDependencies": []
+    }
+}

--- a/e2e/path_mapping/pnpm-lock.yaml
+++ b/e2e/path_mapping/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
+packages:
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.8.3: {}

--- a/e2e/path_mapping/test.sh
+++ b/e2e/path_mapping/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Proves a few things about ts_project's opportunistic use of
-# js_binary_lib.run_binary_action (ts/private/ts_project.bzl):
+# Proves a few things about ts_project's and ts_validate_options's opportunistic
+# use of js_binary_lib.run_binary_action (ts/private/ts_lib.bzl):
 #
 # 1. It lets Bazel's path mapping share a single cached action between two
 #    builds that differ only in compilation mode.
@@ -21,11 +21,11 @@ trap 'rm -rf "$scratch"' EXIT
 disk_cache="$scratch/disk_cache"
 exec_log="$scratch/exec_log.json"
 
-# ts_project's tsc emit action uses use_default_shell_env, so this env var
-# forces the action to be treated as new on every run of this script -- that
-# way a prior local build of the same target/config (e.g. from an earlier run
-# of this script, or from another CI step) can't let Bazel skip it as already
-# up-to-date, which would prevent it from ever consulting our disk cache.
+# Both actions under test use use_default_shell_env, so this env var forces
+# them to be treated as new on every run of this script -- that way a prior
+# local build of the same target/config (e.g. from an earlier run of this
+# script, or from another CI step) can't let Bazel skip them as already
+# up-to-date, which would prevent them from ever consulting our disk cache.
 invalidate="$(date +%s)"
 
 bazel build -c fastbuild //:lib \
@@ -37,28 +37,30 @@ bazel build -c opt //:lib \
 	--action_env="TS_PROJECT_PATH_MAPPING_TEST_INVALIDATE=$invalidate" \
 	--execution_log_json_file="$exec_log"
 
-matches="$(jq -s '[.[] | select(.mnemonic == "TsProject")]' "$exec_log")"
-count="$(echo "$matches" | jq 'length')"
-if [ "$count" -eq 0 ]; then
-	echo "FAIL: no TsProject entry found in the -c opt execution log" >&2
-	exit 1
-fi
+for mnemonic in TsProject TsValidateOptions; do
+	matches="$(jq -s --arg mnemonic "$mnemonic" '[.[] | select(.mnemonic == $mnemonic)]' "$exec_log")"
+	count="$(echo "$matches" | jq 'length')"
+	if [ "$count" -eq 0 ]; then
+		echo "FAIL: no $mnemonic entry found in the -c opt execution log" >&2
+		exit 1
+	fi
 
-cache_hit="$(echo "$matches" | jq -r '.[0].cacheHit')"
-if [ "$cache_hit" != "true" ]; then
-	echo "FAIL: action was re-executed under -c opt (cacheHit=$cache_hit); path mapping did not share the cache entry from -c fastbuild" >&2
-	exit 1
-fi
+	cache_hit="$(echo "$matches" | jq -r '.[0].cacheHit')"
+	if [ "$cache_hit" != "true" ]; then
+		echo "FAIL: $mnemonic action was re-executed under -c opt (cacheHit=$cache_hit); path mapping did not share the cache entry from -c fastbuild" >&2
+		exit 1
+	fi
 
-echo "PASS: action was cache-shared across -c fastbuild and -c opt"
+	echo "PASS: $mnemonic action was cache-shared across -c fastbuild and -c opt"
 
-# We should find via bazel aquery that the action advertises path-mapping
-# support.
-aquery_output="$(bazel aquery 'mnemonic("TsProject", //:lib)')"
-if ! echo "$aquery_output" | grep -q "supports-path-mapping"; then
-	echo "FAIL: supports-path-mapping was not advertised for //:lib" >&2
-	echo "$aquery_output" >&2
-	exit 1
-fi
+	# We should find via bazel aquery that the action advertises path-mapping
+	# support.
+	aquery_output="$(bazel aquery "mnemonic(\"$mnemonic\", //:lib)")"
+	if ! echo "$aquery_output" | grep -q "supports-path-mapping"; then
+		echo "FAIL: supports-path-mapping was not advertised for the $mnemonic action of //:lib" >&2
+		echo "$aquery_output" >&2
+		exit 1
+	fi
 
-echo "PASS: supports-path-mapping is advertised for //:lib"
+	echo "PASS: supports-path-mapping is advertised for the $mnemonic action of //:lib"
+done

--- a/e2e/path_mapping/test.sh
+++ b/e2e/path_mapping/test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Proves a few things about ts_project's opportunistic use of
+# js_binary_lib.run_binary_action (ts/private/ts_project.bzl):
+#
+# 1. It lets Bazel's path mapping share a single cached action between two
+#    builds that differ only in compilation mode.
+# 2. It is advertised via the "supports-path-mapping" execution requirement.
+#
+# A shared --disk_cache is required: -c opt and -c fastbuild are different
+# configurations, so each gets its own action instance the first time Bazel
+# visits it in a given build graph -- the incremental "did anything change"
+# check within one build never gets a chance to compare across them. Only an
+# explicit disk (or remote) cache lookup, keyed by the path-mapped action
+# digest, can serve the second build's action from the first build's result.
+set -o errexit -o nounset -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+disk_cache="$scratch/disk_cache"
+exec_log="$scratch/exec_log.json"
+
+# ts_project's tsc emit action uses use_default_shell_env, so this env var
+# forces the action to be treated as new on every run of this script -- that
+# way a prior local build of the same target/config (e.g. from an earlier run
+# of this script, or from another CI step) can't let Bazel skip it as already
+# up-to-date, which would prevent it from ever consulting our disk cache.
+invalidate="$(date +%s)"
+
+bazel build -c fastbuild //:lib \
+	--disk_cache="$disk_cache" \
+	--action_env="TS_PROJECT_PATH_MAPPING_TEST_INVALIDATE=$invalidate"
+
+bazel build -c opt //:lib \
+	--disk_cache="$disk_cache" \
+	--action_env="TS_PROJECT_PATH_MAPPING_TEST_INVALIDATE=$invalidate" \
+	--execution_log_json_file="$exec_log"
+
+matches="$(jq -s '[.[] | select(.mnemonic == "TsProject")]' "$exec_log")"
+count="$(echo "$matches" | jq 'length')"
+if [ "$count" -eq 0 ]; then
+	echo "FAIL: no TsProject entry found in the -c opt execution log" >&2
+	exit 1
+fi
+
+cache_hit="$(echo "$matches" | jq -r '.[0].cacheHit')"
+if [ "$cache_hit" != "true" ]; then
+	echo "FAIL: action was re-executed under -c opt (cacheHit=$cache_hit); path mapping did not share the cache entry from -c fastbuild" >&2
+	exit 1
+fi
+
+echo "PASS: action was cache-shared across -c fastbuild and -c opt"
+
+# We should find via bazel aquery that the action advertises path-mapping
+# support.
+aquery_output="$(bazel aquery 'mnemonic("TsProject", //:lib)')"
+if ! echo "$aquery_output" | grep -q "supports-path-mapping"; then
+	echo "FAIL: supports-path-mapping was not advertised for //:lib" >&2
+	echo "$aquery_output" >&2
+	exit 1
+fi
+
+echo "PASS: supports-path-mapping is advertised for //:lib"

--- a/e2e/path_mapping/test.sh
+++ b/e2e/path_mapping/test.sh
@@ -28,16 +28,37 @@ exec_log="$scratch/exec_log.json"
 # up-to-date, which would prevent them from ever consulting our disk cache.
 invalidate="$(date +%s)"
 
-bazel build -c fastbuild //:lib \
+# //:lib_isolated_typecheck sets isolated_typecheck = True, which makes tsc
+# type-checking run as its own TsProjectCheck action separate from the
+# TsProject(Emit) action. That action is only built as part of the
+# "_typecheck" filegroup target the ts_project macro generates, not as part of
+# the default outputs. This is what exercises run_binary_action's use in
+# ts_project's isolated typecheck action.
+targets=(//:lib //:lib_isolated_typecheck_typecheck)
+
+bazel build -c fastbuild "${targets[@]}" \
 	--disk_cache="$disk_cache" \
 	--action_env="TS_PROJECT_PATH_MAPPING_TEST_INVALIDATE=$invalidate"
 
-bazel build -c opt //:lib \
+bazel build -c opt "${targets[@]}" \
 	--disk_cache="$disk_cache" \
 	--action_env="TS_PROJECT_PATH_MAPPING_TEST_INVALIDATE=$invalidate" \
 	--execution_log_json_file="$exec_log"
 
-for mnemonic in TsProject TsValidateOptions; do
+# mnemonic:target pairs to check via aquery. The target must be the
+# underlying ts_project rule itself (not a wrapping filegroup) since aquery
+# does not surface a filegroup's generating action when it re-exports a
+# non-default output group, as the "_typecheck" filegroup does.
+mnemonic_targets=(
+	"TsProject:lib"
+	"TsValidateOptions:lib"
+	"TsProjectCheck:lib_isolated_typecheck"
+)
+
+for entry in "${mnemonic_targets[@]}"; do
+	mnemonic="${entry%%:*}"
+	target="${entry#*:}"
+
 	matches="$(jq -s --arg mnemonic "$mnemonic" '[.[] | select(.mnemonic == $mnemonic)]' "$exec_log")"
 	count="$(echo "$matches" | jq 'length')"
 	if [ "$count" -eq 0 ]; then
@@ -55,12 +76,12 @@ for mnemonic in TsProject TsValidateOptions; do
 
 	# We should find via bazel aquery that the action advertises path-mapping
 	# support.
-	aquery_output="$(bazel aquery "mnemonic(\"$mnemonic\", //:lib)")"
+	aquery_output="$(bazel aquery "mnemonic(\"$mnemonic\", //:$target)")"
 	if ! echo "$aquery_output" | grep -q "supports-path-mapping"; then
-		echo "FAIL: supports-path-mapping was not advertised for the $mnemonic action of //:lib" >&2
+		echo "FAIL: supports-path-mapping was not advertised for the $mnemonic action of //:$target" >&2
 		echo "$aquery_output" >&2
 		exit 1
 	fi
 
-	echo "PASS: supports-path-mapping is advertised for the $mnemonic action of //:lib"
+	echo "PASS: supports-path-mapping is advertised for the $mnemonic action of //:$target"
 done

--- a/e2e/path_mapping/tsconfig.json
+++ b/e2e/path_mapping/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "module": "nodenext",
+        "target": "esnext",
+        "types": [],
+        "sourceMap": true,
+        "declaration": true,
+        "strict": true,
+        "isolatedModules": true,
+        "skipLibCheck": true
+    }
+}

--- a/e2e/path_mapping/tsconfig.json
+++ b/e2e/path_mapping/tsconfig.json
@@ -7,6 +7,7 @@
         "declaration": true,
         "strict": true,
         "isolatedModules": true,
+        "isolatedDeclarations": true,
         "skipLibCheck": true
     }
 }

--- a/ts/private/ts_lib.bzl
+++ b/ts/private/ts_lib.bzl
@@ -1,6 +1,8 @@
 "Utilities functions for selecting and filtering ts and other files"
 
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 # Attributes common to all TypeScript rules
 STD_ATTRS = {
@@ -420,6 +422,26 @@ def _declare_outputs(ctx, paths):
         for path in paths
     ]
 
+# js_binary_lib.run_binary_action is only available in aspect_rules_js 3.4.0
+# and higher. Opportunistically use it when present, since bumping our minimum
+# supported aspect_rules_js version would be a breaking change.
+def _run_binary_action(ctx, env = None, execution_requirements = None, **kwargs):
+    env = env or {}
+    execution_requirements = execution_requirements or {}
+    if hasattr(js_binary_lib, "run_binary_action"):
+        js_binary_lib.run_binary_action(
+            ctx = ctx,
+            env = env,
+            execution_requirements = dicts.add(execution_requirements, {"supports-path-mapping": "1"}),
+            **kwargs
+        )
+    else:
+        ctx.actions.run(
+            env = dicts.add(env, {"BAZEL_BINDIR": ctx.bin_dir.path}),
+            execution_requirements = execution_requirements,
+            **kwargs
+        )
+
 lib = struct(
     declare_outputs = _declare_outputs,
     join = _join,
@@ -431,4 +453,5 @@ lib = struct(
     validate_tsconfig_dirs = _validate_tsconfig_dirs,
     calculate_outs = _calculate_outs,
     calculate_root_dir = _calculate_root_dir,
+    run_binary_action = _run_binary_action,
 )

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -5,7 +5,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "c
 load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
 load("@aspect_bazel_lib//lib:platform_utils.bzl", "platform_utils")
 load("@aspect_bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
-load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
+load("@aspect_rules_js//js:libs.bzl", "js_binary_lib", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":options.bzl", "OptionsInfo", "transpiler_selection_required")
@@ -36,6 +36,26 @@ def _gather_transitive_typecheck_from_output_group_infos(typecheck_outs, targets
         if OutputGroupInfo in target and "transitive_typecheck" in target[OutputGroupInfo]
     ]
     return depset(typecheck_outs, transitive = files_depsets)
+
+# js_binary_lib.run_binary_action is only available in aspect_rules_js 3.4.0
+# and higher. Opportunistically use it when present, since bumping our minimum
+# supported aspect_rules_js version would be a breaking change.
+def _run_tsc_action(ctx, env = None, execution_requirements = None, **kwargs):
+    env = env or {}
+    execution_requirements = execution_requirements or {}
+    if hasattr(js_binary_lib, "run_binary_action"):
+        js_binary_lib.run_binary_action(
+            ctx = ctx,
+            env = env,
+            execution_requirements = dicts.add(execution_requirements, {"supports-path-mapping": "1"}),
+            **kwargs
+        )
+    else:
+        ctx.actions.run(
+            env = dicts.add(env, {"BAZEL_BINDIR": ctx.bin_dir.path}),
+            execution_requirements = execution_requirements,
+            **kwargs
+        )
 
 def _gather_tsconfig_deps(ctx):
     tsconfig = copy_file_to_bin_action(ctx, ctx.file.tsconfig)
@@ -355,7 +375,8 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             type_check_part = " & type-checking" if not ctx.attr.isolated_typecheck else "",
         )
 
-        ctx.actions.run(
+        _run_tsc_action(
+            ctx,
             executable = executable,
             inputs = inputs_depset,
             arguments = [tsc_emit_arguments],
@@ -364,9 +385,6 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             execution_requirements = execution_requirements,
             resource_set = resource_set(ctx.attr),
             progress_message = progress_message,
-            env = {
-                "BAZEL_BINDIR": ctx.bin_dir.path,
-            },
             use_default_shell_env = True,
         )
 

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -5,7 +5,7 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "c
 load("@aspect_bazel_lib//lib:paths.bzl", "to_output_relative_path")
 load("@aspect_bazel_lib//lib:platform_utils.bzl", "platform_utils")
 load("@aspect_bazel_lib//lib:resource_sets.bzl", "resource_set", "resource_set_attr")
-load("@aspect_rules_js//js:libs.bzl", "js_binary_lib", "js_lib_helpers")
+load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":options.bzl", "OptionsInfo", "transpiler_selection_required")
@@ -36,26 +36,6 @@ def _gather_transitive_typecheck_from_output_group_infos(typecheck_outs, targets
         if OutputGroupInfo in target and "transitive_typecheck" in target[OutputGroupInfo]
     ]
     return depset(typecheck_outs, transitive = files_depsets)
-
-# js_binary_lib.run_binary_action is only available in aspect_rules_js 3.4.0
-# and higher. Opportunistically use it when present, since bumping our minimum
-# supported aspect_rules_js version would be a breaking change.
-def _run_tsc_action(ctx, env = None, execution_requirements = None, **kwargs):
-    env = env or {}
-    execution_requirements = execution_requirements or {}
-    if hasattr(js_binary_lib, "run_binary_action"):
-        js_binary_lib.run_binary_action(
-            ctx = ctx,
-            env = env,
-            execution_requirements = dicts.add(execution_requirements, {"supports-path-mapping": "1"}),
-            **kwargs
-        )
-    else:
-        ctx.actions.run(
-            env = dicts.add(env, {"BAZEL_BINDIR": ctx.bin_dir.path}),
-            execution_requirements = execution_requirements,
-            **kwargs
-        )
 
 def _gather_tsconfig_deps(ctx):
     tsconfig = copy_file_to_bin_action(ctx, ctx.file.tsconfig)
@@ -375,7 +355,7 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             type_check_part = " & type-checking" if not ctx.attr.isolated_typecheck else "",
         )
 
-        _run_tsc_action(
+        _lib.run_binary_action(
             ctx,
             executable = executable,
             inputs = inputs_depset,

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -265,9 +265,11 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
     if ctx.attr.isolated_typecheck or not (use_tsc_for_js or use_tsc_for_dts):
         typecheck_outputs = []
 
-        # The type-checking action still need to produce some output, so we output the stdout
-        # to a .typecheck file that ends up in the typecheck output group.
-        typecheck_output = ctx.actions.declare_file(ctx.attr.name + ".typecheck")
+        # The type-checking action does not produce any real output, so we declare an
+        # empty directory as a marker output just so that Bazel has something to depend
+        # on. Bazel pre-creates the directory itself before running the action, so tsc
+        # does not need to write anything into it.
+        typecheck_output = ctx.actions.declare_directory(ctx.attr.name + ".typecheck")
         typecheck_outs.append(typecheck_output)
         typecheck_outputs.append(typecheck_output)
 
@@ -281,28 +283,17 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             typecheck_outputs.append(tsc_trace_dir)
             typecheck_arguments.add_all(["--generateTrace", to_output_relative_path(tsc_trace_dir)])
 
-        env = {
-            "BAZEL_BINDIR": ctx.bin_dir.path,
-        }
-
-        # In non-worker mode, we create the marker file by capturing stdout of the action
-        # via the JS_BINARY__STDOUT_OUTPUT_FILE environment variable, but in worker mode, the
-        # persistent worker protocol communicates with the worker process via stdin/stdout, so
-        # the output cannot just be captured. Instead, we tell the worker where to write the
-        # marker file by passing the path via the --bazelValidationFile flag.
         if supports_workers:
             typecheck_arguments.use_param_file("@%s", use_always = True)
             typecheck_arguments.set_param_file_format("multiline")
-            typecheck_arguments.add("--bazelValidationFile", typecheck_output.short_path)
-        else:
-            env["JS_BINARY__STDOUT_OUTPUT_FILE"] = typecheck_output.path
 
         progress_message = ctx.attr.isolated_typecheck_progress_message.format(
             label = ctx.label,
             tsconfig_path = tsconfig_path,
         )
 
-        ctx.actions.run(
+        _lib.run_binary_action(
+            ctx,
             executable = executable,
             inputs = tsc_transitive_inputs_depset,
             arguments = [typecheck_arguments],
@@ -311,7 +302,7 @@ See https://github.com/aspect-build/rules_ts/issues/361 for more details.
             execution_requirements = execution_requirements,
             resource_set = resource_set(ctx.attr),
             progress_message = progress_message,
-            env = env,
+            use_default_shell_env = True,
         )
     else:
         # When tsc emits js but no dts, js_outs are the only artifact proving tsc ran and type-checked.

--- a/ts/private/ts_project_worker.js
+++ b/ts/private/ts_project_worker.js
@@ -880,11 +880,6 @@ async function emit(request) {
     debug(`# Beginning new work`);
     debug(`arguments: ${request.arguments.join(' ')}`)
 
-    if (request.arguments.includes('--bazelValidationFile')) {
-        const [, validationPath] = request.arguments.splice(request.arguments.indexOf('--bazelValidationFile'), 2);
-        fs.writeFileSync(path.resolve(process.cwd(), validationPath), '');
-    }
-
     const inputs = Object.fromEntries(
         request.inputs.map(input => [
             input.path,
@@ -997,11 +992,6 @@ if (require.main === module && worker_protocol.isPersistentWorker(process.argv))
         p = path.resolve('..', '..', '..', p.slice(1));
     }
     const args = fs.readFileSync(p).toString().trim().split('\n');
-
-    if (args.includes('--bazelValidationFile')) {
-        const [, validationPath] = args.splice(args.indexOf('--bazelValidationFile'), 2);
-        fs.writeFileSync(path.resolve(process.cwd(), validationPath), '');
-    }
 
     ts.sys.args = process.argv = [process.argv0, process.argv[1], ...args];
     execute(ts.sys, ts.noop, args);

--- a/ts/private/ts_validate_options.bzl
+++ b/ts/private/ts_validate_options.bzl
@@ -38,15 +38,13 @@ Assumes all tsconfig file deps are already copied to the bin directory.
         json.encode(config),
     ])
 
-    ctx.actions.run(
+    _lib.run_binary_action(
+        ctx,
         executable = ctx.executable.validator,
         inputs = tsconfig_deps,
         outputs = [marker],
         arguments = [arguments],
         mnemonic = "TsValidateOptions",
-        env = {
-            "BAZEL_BINDIR": ctx.bin_dir.path,
-        },
         use_default_shell_env = True,
     )
 


### PR DESCRIPTION
Use `js_binary_lib.run_binary_action` when available so that the tsc emit action advertises `supports-path-mapping` and can share its cache across compilation modes.

We have to be prepared for the absence of `run_binary_action`, because it will only be available starting from rules_js v3.4.0. We cannot just upgrade our minimum rules_js dependency since that would be a breaking change.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Support path mapping in ts_project when possible

### Test plan

- Covered by existing test cases
- New test cases added