### PR TITLE
fix: emit source dts files in ts_project output (#984)

### DIFF
--- a/examples/dts_srcs/BUILD.bazel
+++ b/examples/dts_srcs/BUILD.bazel
@@ -1,0 +1,65 @@
+"""ts_project(srcs) containing .d.ts files with various outDir/rootDir settings.
+
+A .d.ts src is never transpiled or relocated by tsc, so it is passed through to
+JsInfo(types) (the `types` output group) at its source location.
+"""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@bazel_lib//lib:testing.bzl", "assert_outputs")
+
+ts_project(
+    name = "default",
+    srcs = [
+        "index.ts",
+        "types.d.ts",
+    ],
+    declaration = True,
+)
+
+assert_outputs(
+    name = "default_types_test",
+    actual = ":default_types",
+    expected = [
+        "dts_srcs/index.d.ts",
+        "dts_srcs/types.d.ts",
+    ],
+)
+
+ts_project(
+    name = "out_dir",
+    srcs = [
+        "index.ts",
+        "types.d.ts",
+    ],
+    declaration = True,
+    out_dir = "dist",
+)
+
+assert_outputs(
+    name = "out_dir_types_test",
+    actual = ":out_dir_types",
+    expected = [
+        "dts_srcs/dist/index.d.ts",
+        "dts_srcs/types.d.ts",
+    ],
+)
+
+ts_project(
+    name = "root_dir_out_dir",
+    srcs = [
+        "src/index.ts",
+        "src/types.d.ts",
+    ],
+    declaration = True,
+    out_dir = "dist2",
+    root_dir = "src",
+)
+
+assert_outputs(
+    name = "root_dir_out_dir_types_test",
+    actual = ":root_dir_out_dir_types",
+    expected = [
+        "dts_srcs/dist2/index.d.ts",
+        "dts_srcs/src/types.d.ts",
+    ],
+)

--- a/examples/dts_srcs/index.ts
+++ b/examples/dts_srcs/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export const value = 1

--- a/examples/dts_srcs/src/index.ts
+++ b/examples/dts_srcs/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export const value = 1

--- a/examples/dts_srcs/src/types.d.ts
+++ b/examples/dts_srcs/src/types.d.ts
@@ -1,0 +1,1 @@
+export type A = number

--- a/examples/dts_srcs/tsconfig.json
+++ b/examples/dts_srcs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "declaration": true
+    }
+}

--- a/examples/dts_srcs/types.d.ts
+++ b/examples/dts_srcs/types.d.ts
@@ -1,0 +1,1 @@
+export type A = number

--- a/ts/private/ts_project.bzl
+++ b/ts/private/ts_project.bzl
@@ -190,7 +190,7 @@ def _ts_project_impl(ctx):
     #
     # Unfortunately this duplicates logic in ts_lib.calculate_outs:
     # files collide iff the following conditions are met:
-    # - They are files not renamed when transpiled (ext in [.d.ts, js, json])
+    # - They are files not renamed when transpiled (ext in [js, json])
     # - out_dir == root_dir
     #
     # The duplication is hard to avoid, since calculate_outs works on path strings
@@ -199,8 +199,11 @@ def _ts_project_impl(ctx):
         for s in srcs_inputs:
             if _lib.is_js_src(s.path, ctx.attr.allow_js, ctx.attr.resolve_json_module):
                 output_sources.append(s)
-            if _lib.is_typings_src(s.path):
-                output_types.append(s)
+
+    # Add .d.ts inputs which are never emitted by tsc.
+    for s in srcs_inputs:
+        if _lib.is_typings_src(s.path):
+            output_types.append(s)
 
     is_root_module = ctx.label.workspace_root == ""
 


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Source `ts_project(srcs)` dts files are now passed through to the resulting `JsInfo` as-is with no modifications or outDir/rootDir applied just like `tsc` does not emit them while emitted dts may still depend on them.

### Test plan

- Covered by existing test cases
- New test cases added